### PR TITLE
Add reader width to utility classes

### DIFF
--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -1,12 +1,14 @@
 /* Core Utility Classes
   =========================================================================== */
 //content width
-$content-s:     350px;
-$content-m:     800px;
-$content-l:     1200px;
-$content-full:  auto;
+$content-xs:     350px;
+$content-s:      600px;
+$content-m:      800px;
+$content-l:      1200px;
+$content-full:   auto;
 
 $widths: (
+  "-xs":    #{$content-xs},
   "-s":     #{$content-s},
   "-m":     #{$content-m},
   "-l":     #{$content-l},
@@ -16,7 +18,7 @@ $widths: (
 @each $width, $width-var in $widths {
   $max-width: if($width == '', '', #{$width-var});
   .content#{$width} { //.content-s
-    max-width: #{$max-width} !important; //max-width: 350px;
+    max-width: #{$max-width} !important; //max-width: 600px;
   }
 }
 

--- a/src/sass/dashboard/overpanel.scss
+++ b/src/sass/dashboard/overpanel.scss
@@ -8,7 +8,7 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      max-width: $content-m;
+      max-width: $content-s;
       margin: 0 auto;
       padding: $space-m;
       * { margin: 0; } //to overwrite global margin bottom
@@ -17,15 +17,27 @@
   }
 
   .content {
-    max-width: $content-m;
+    max-width: $content-s;
     margin-top: 0;
   }
 
   /* Utility classes for max-width of Overpanel */
+  &.overpanel-xs {
+    .title-content,
+    .content {
+      max-width: $content-xs;
+    }
+  }
   &.overpanel-s {
     .title-content,
     .content {
       max-width: $content-s;
+    }
+  }
+  &.overpanel-m {
+    .title-content,
+    .content {
+      max-width: $content-m;
     }
   }
   &.overpanel-l {


### PR DESCRIPTION
Changed around the content utilities a bit (added 600px as content-s):

- $content-xs: 350px
- $content-s: 600px
- $content-m: 800px
- $content-l: 1200px