### PR TITLE
Fixes color of default button-icons

### DIFF
--- a/src/sass/modules/actions/_actions.scss
+++ b/src/sass/modules/actions/_actions.scss
@@ -189,6 +189,10 @@ $button-disabled: "&[disabled], &.disabled, &.button--disabled";
     padding: $space-m;
     &:active { @extend %shadow-50; }
   }
+
+  &.button--transparent { //makes default transparent button icon gray, rather than blue
+    @include transparent--button($color: $gray-700);
+  }
 }
 
 //Provides margin when a button and action are paired together


### PR DESCRIPTION
With the recent merge, default button icons reverted to blue. This makes them gray(t) again.