### PR TITLE
Position dropdown arrow relative to top

### DIFF
--- a/src/sass/modules/forms/forms.scss
+++ b/src/sass/modules/forms/forms.scss
@@ -125,13 +125,13 @@ fieldset {
       font-weight: 600;
       pointer-events: none;
       position: absolute;
-      right: 2rem; bottom: calc(#{$grid-gutter} * 2);
+      right: 2rem;
+      top: 2.4rem;
     }
 
     .grid & { //supports select positioning in grid
       &:after {
         right: 1rem;
-        bottom: 2rem;
       }
     }
 


### PR DESCRIPTION
Seems standard practice to position dropdown arrow relative to the top. This would break if our input label somehow became more then 1 line... but other design system drop-downs break from the same occurrence. 
<img width="605" alt="screen shot 2019-02-19 at 11 38 35 am" src="https://user-images.githubusercontent.com/26393016/53035997-5dece880-343c-11e9-9df7-1ffd6c7ea8a6.png">
