### PR TITLE
Mobile Card & Card Margin

### DIFF
--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -9,7 +9,16 @@
   margin: 1.5rem auto;
   @extend %card-shadow;
 
-  .grid & { margin-bottom: $space-m; }
+  .grid & {
+    @media #{$phone} { //remove card within grid padding on mobile
+      margin: $grid-gutter -#{$grid-gutter};
+      border-radius: 0;
+    }
+    margin: 0 0 $space-m 0;
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
 
   @media #{$phone} {
     .grid {


### PR DESCRIPTION
**Remove card padding on mobile**
This code recently got removed from Paragon. But cards will now go up to the side of the screen on mobile.

**Properly adjust card margin for use in grid**
Removed card margin if it is the last card within a grid. This keeps this card margin from doubling up the `grid-padding`