### PR TITLE
Improved Focus Styles

### DIFF
--- a/src/sass/example-page/example-page.scss
+++ b/src/sass/example-page/example-page.scss
@@ -213,6 +213,7 @@ $sidebar-width:  13rem;
     padding-left: 1rem;
     a {
       text-transform: uppercase;
+      text-decoration: none;
       color: white;
       margin-right: 1rem;
       padding-bottom: 0.3rem;

--- a/src/sass/modules/actions/_actions.scss
+++ b/src/sass/modules/actions/_actions.scss
@@ -3,6 +3,7 @@
 
 $buttons: ".button, button, input[type='submit'], input[type='reset']";
 $button-disabled: "&[disabled], &.disabled, &.button--disabled";
+$action--focus: $blue-300 !default;
 
 /* Actions Extendables
   =========================================================================== */
@@ -20,6 +21,7 @@ $button-disabled: "&[disabled], &.disabled, &.button--disabled";
   &:first-of-type { margin-left: 0; } //Clears left margin of first %action element
   &:last-of-type { margin-right: 0; } //Clears right margin of last %action element
   &:hover { transition: all .1s ease-in-out; }
+  &:focus { box-shadow: 0 0 0 4px $action--focus; }
 }
 
 /* Actions Styles

--- a/src/sass/modules/banner/_banner.scss
+++ b/src/sass/modules/banner/_banner.scss
@@ -42,9 +42,12 @@
     color: inherit;
     cursor: pointer;
 
+    &:focus,
     &:hover {
-    opacity: 0.6;
-    transition: all 50ms ease-in-out;
+      opacity: 0.6;
+      transition: all 50ms ease-in-out;
+      text-decoration: none;
+      color: inherit;
     }
   }
 

--- a/src/sass/modules/navigation/navigation.scss
+++ b/src/sass/modules/navigation/navigation.scss
@@ -57,7 +57,8 @@ $header-shadow: 0px 1px 5px rgba(0, 0, 0, 0.5) !default;
           font-weight: 600;
           font-size: 1.1rem;
           border-bottom: 2px solid transparent;
-          @include transition(0.2s ease-out);
+          text-decoration: none;
+          @include transition(border-bottom 0.2s ease-out);
 
           &:hover, &.active { border-bottom: 2px solid $sub-nav-color; }
 
@@ -125,9 +126,10 @@ $header-shadow: 0px 1px 5px rgba(0, 0, 0, 0.5) !default;
         color: $header-color;
         font-weight: 600;
         font-size: 1rem;
-        @include transition(0.2s ease-out);
-
+        text-decoration: none;
         border-bottom: 3px solid transparent;
+        @include transition(border-bottom 0.2s ease-out);
+
         &:hover, &.active  { border-bottom: 3px solid $header-color; }
       }
     }

--- a/src/sass/modules/typography/_typography.scss
+++ b/src/sass/modules/typography/_typography.scss
@@ -70,10 +70,13 @@ a {
   color: $blue;
   cursor: pointer;
   font-weight: $font-weight-semibold;
-  outline: none;
   text-decoration: none;
 
-  &:hover, &:focus { color: $blue-400; }
+  &:hover, &:focus {
+    color: $blue-400;
+    text-decoration: underline;
+    text-decoration-color: inherit;
+  }
 }
 
 p, li.text-list_item {


### PR DESCRIPTION
Wanted to get the discussion started on focus styles... let me know your thoughts, concerns, etc.
_Note: None of this has been device tested yet_

---

**Links**
Add default focus ring on focus
<img width="91" alt="Screen Shot 2019-03-12 at 3 31 26 PM" src="https://user-images.githubusercontent.com/26393016/54234228-b1eb6a00-44dc-11e9-98f1-02c2ee2c124a.png">

Add text-decoration underline to link on hover/focus
<img width="85" alt="Screen Shot 2019-03-12 at 3 31 17 PM" src="https://user-images.githubusercontent.com/26393016/54234248-bdd72c00-44dc-11e9-9c21-2862637d4d64.png">

**Actions**
Custom focus style on tab
- Utilized the box-shadow custom checkboxes and radio buttons use for hover
<img width="786" alt="Screen Shot 2019-03-12 at 3 32 09 PM" src="https://user-images.githubusercontent.com/26393016/54234304-d6474680-44dc-11e9-9a95-e57dfa93851e.png">
<img width="69" alt="Screen Shot 2019-03-12 at 3 32 29 PM" src="https://user-images.githubusercontent.com/26393016/54234305-d6474680-44dc-11e9-8c4b-9400f92661ac.png">

