### PR TITLE
Add CSS Grid desktop sizing classes

### DIFF
--- a/src/pages/components/css-grid/code.js
+++ b/src/pages/components/css-grid/code.js
@@ -95,6 +95,30 @@ class CssGridCode extends React.Component {
     </div>`}
               </CodeToggle>
 
+              <h2 className="example-header" id="gridMultipleBreakpoints">Multiple Grid Breakpoints
+                <Link to={location.pathname + "/#gridMultipleBreakpoints"} className="button button--transparent button--copy-link"></Link>
+              </h2>
+              <p>To resize a grid for different breakpoints, use a combination of classes. You can add <code className="example-text">_desktop</code> to any grid class to apply to the desktop breakpoint.</p>
+              <div className="row example-container">
+                <div className="column column--full">
+                  <div className="grid grid--full grid-highlight-blue">
+                    <div className="grid--two-thirds grid--half_desktop">.grid--two-thirds .grid--half_desktop</div>
+                    <div className="grid--third grid--full_desktop">.grid--third .grid--full_desktop</div>
+                    <div className="grid--full">.grid--full</div>
+                  </div>
+                </div>
+              </div>
+              <CodeToggle>
+    {`<!-- Grid Example -->
+<div class="grid grid--full grid-highlight-blue">
+<!-- Grid is two-thirds on tablet and changes to half on desktop -->
+  <div class="grid--two-thirds grid--half_desktop">.grid--two-thirds .grid--half_desktop</div>
+  <!-- Grid is one third on tablet and changes to full on desktop -->
+  <div class="grid--third grid--full_desktop">.grid--third .grid--full_desktop</div>
+  <div class="grid--full">.grid--full</div>
+</div>`}
+              </CodeToggle>
+
               <h2 className="example-header" id="nestedGrids">Nested Grids
                 <Link to={location.pathname + "/#nestedGrids"} className="button button--transparent button--copy-link"></Link>
               </h2>

--- a/src/pages/templates/default.js
+++ b/src/pages/templates/default.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'gatsby'
 // The scss needs to be imported here for running 'gatsby build'
-import '../../sass/example-page/example-page.scss'
+//import '../../sass/example-page/example-page.scss'
 
 export default () => (
 
@@ -37,13 +37,17 @@ export default () => (
 
 	<main className="content">
 		<div className="grid grid-padding">
+			<div className="grid--full grid--half_desktop">
 
-			<div>
-				<h1>Primary Header</h1>
-				<p>Header description</p>
-				<Link to="/templates/overpanel">Full Page</Link>
+				<div className="card">
+					<div className="card-content">
+						<h1>Primary Header</h1>
+						<p>Header description</p>
+						<Link to="/templates/overpanel">Full Page</Link>
+					</div>
+				</div>
+
 			</div>
-
 		</div>
 	</main>
 </React.Fragment>

--- a/src/pages/templates/default.js
+++ b/src/pages/templates/default.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'gatsby'
 // The scss needs to be imported here for running 'gatsby build'
-//import '../../sass/example-page/example-page.scss'
+import '../../sass/example-page/example-page.scss'
 
 export default () => (
 

--- a/src/sass/modules/css-grid/css-grid-fallbacks.scss
+++ b/src/sass/modules/css-grid/css-grid-fallbacks.scss
@@ -4,14 +4,22 @@ Fallback Classes (Must be First)
 
 //12 10 9 8 6 4 3 2
 .grid { grid-template-columns: repeat(12, 1fr);
-	.grid--full,          .grid-12 { @include fallback-grid(100%); }
-	.grid--five-sixths,   .grid-10 { @include fallback-grid(83.3333%); }
-	.grid--three-fourths, .grid-9  { @include fallback-grid(75%); }
-	.grid--two-thirds,    .grid-8  { @include fallback-grid(66.6666%); }
-	.grid--half,          .grid-6  { @include fallback-grid(50%); }
-	.grid--third,         .grid-4  { @include fallback-grid(33.3333%); }
-	.grid--fourth,        .grid-3  { @include fallback-grid(25%);  }
-	.grid--sixth,         .grid-2  { @include fallback-grid(16.6666%); }
+	.grid--full,          				.grid-12,
+	.grid--full_desktop,  				.grid-12_desktop { @include fallback-grid(100%); }
+	.grid--five-sixths,   				.grid-10,
+	.grid--five-sixths_desktop,   .grid-10_desktop { @include fallback-grid(83.3333%); }
+	.grid--three-fourths, 				.grid-9,
+	.grid--three-fourths_desktop, .grid-9_desktop  { @include fallback-grid(75%); }
+	.grid--two-thirds,    				.grid-8,
+	.grid--two-thirds_desktop,    .grid-8_desktop  { @include fallback-grid(66.6666%); }
+	.grid--half,          				.grid-6,
+	.grid--half_desktop,          .grid-6_desktop  { @include fallback-grid(50%); }
+	.grid--third,         				.grid-4,
+	.grid--third_desktop,         .grid-4_desktop  { @include fallback-grid(33.3333%); }
+	.grid--fourth,        				.grid-3,
+	.grid--fourth_desktop,        .grid-3_desktop  { @include fallback-grid(25%);  }
+	.grid--sixth,         				.grid-2,
+	.grid--sixth_desktop,         .grid-2_desktop  { @include fallback-grid(16.6666%); }
 
 	> * {
 		float: left;

--- a/src/sass/modules/css-grid/css-grid-fallbacks.scss
+++ b/src/sass/modules/css-grid/css-grid-fallbacks.scss
@@ -4,22 +4,23 @@ Fallback Classes (Must be First)
 
 //12 10 9 8 6 4 3 2
 .grid { grid-template-columns: repeat(12, 1fr);
-	.grid--full,          				.grid-12,
-	.grid--full_desktop,  				.grid-12_desktop { @include fallback-grid(100%); }
-	.grid--five-sixths,   				.grid-10,
-	.grid--five-sixths_desktop,   .grid-10_desktop { @include fallback-grid(83.3333%); }
-	.grid--three-fourths, 				.grid-9,
-	.grid--three-fourths_desktop, .grid-9_desktop  { @include fallback-grid(75%); }
-	.grid--two-thirds,    				.grid-8,
-	.grid--two-thirds_desktop,    .grid-8_desktop  { @include fallback-grid(66.6666%); }
-	.grid--half,          				.grid-6,
-	.grid--half_desktop,          .grid-6_desktop  { @include fallback-grid(50%); }
-	.grid--third,         				.grid-4,
-	.grid--third_desktop,         .grid-4_desktop  { @include fallback-grid(33.3333%); }
-	.grid--fourth,        				.grid-3,
-	.grid--fourth_desktop,        .grid-3_desktop  { @include fallback-grid(25%);  }
-	.grid--sixth,         				.grid-2,
-	.grid--sixth_desktop,         .grid-2_desktop  { @include fallback-grid(16.6666%); }
+	.grid--full,          				.grid-12	{ @include fallback-grid(100%); }
+	.grid--five-sixths,   				.grid-10	{ @include fallback-grid(83.3333%); }
+	.grid--three-fourths, 				.grid-9	  { @include fallback-grid(75%); }
+	.grid--two-thirds,    				.grid-8	  { @include fallback-grid(66.6666%); }
+	.grid--half,          				.grid-6	  { @include fallback-grid(50%); }
+	.grid--third,         				.grid-4	  { @include fallback-grid(33.3333%); }
+	.grid--fourth,        				.grid-3   { @include fallback-grid(25%);  }
+	.grid--sixth,         				.grid-2   { @include fallback-grid(16.6666%); }
+
+	.grid--full_desktop,  				.grid-12_desktop { @include fallback-grid_desktop(100%); }
+	.grid--five-sixths_desktop,   .grid-10_desktop { @include fallback-grid_desktop(83.3333%); }
+	.grid--three-fourths_desktop, .grid-9_desktop  { @include fallback-grid_desktop(75%); }
+	.grid--two-thirds_desktop,    .grid-8_desktop  { @include fallback-grid_desktop(66.6666%); }
+	.grid--half_desktop,          .grid-6_desktop  { @include fallback-grid_desktop(50%); }
+	.grid--third_desktop,         .grid-4_desktop  { @include fallback-grid_desktop(33.3333%); }
+	.grid--fourth_desktop,        .grid-3_desktop  { @include fallback-grid_desktop(25%);  }
+	.grid--sixth_desktop,         .grid-2_desktop  { @include fallback-grid_desktop(16.6666%); }
 
 	> * {
 		float: left;

--- a/src/sass/modules/css-grid/css-grid-main.scss
+++ b/src/sass/modules/css-grid/css-grid-main.scss
@@ -31,6 +31,7 @@ Actual CSS Grid Classes
 	}
 
 	grid-template-columns: repeat(12, 1fr);
+
 	//12 10 9 8 6 4 3 2
 	.grid--full,          .grid-12  { @include grid-column(12); }
 	.grid--five-sixths,   .grid-10  { @include grid-column(10); }
@@ -40,6 +41,16 @@ Actual CSS Grid Classes
 	.grid--third,         .grid-4   { @include grid-column(4); }
 	.grid--fourth,        .grid-3   { @include grid-column(3); }
 	.grid--sixth,         .grid-2   { @include grid-column(2); }
+
+	//Desktop mixin for 12 10 9 8 6 4 3 2
+	.grid--full_desktop,  				.grid-12_desktop  { @include grid-column_desktop(12); }
+	.grid--five-sixths_desktop,   .grid-10_desktop  { @include grid-column_desktop(10); }
+	.grid--three-fourths_desktop, .grid-9_desktop   { @include grid-column_desktop(9); }
+	.grid--two-thirds_desktop,    .grid-8_desktop   { @include grid-column_desktop(8); }
+	.grid--half_desktop,          .grid-6_desktop   { @include grid-column_desktop(6); }
+	.grid--third_desktop,         .grid-4_desktop   { @include grid-column_desktop(4); }
+	.grid--fourth_desktop,        .grid-3_desktop   { @include grid-column_desktop(3); }
+	.grid--sixth_desktop,         .grid-2_desktop   { @include grid-column_desktop(2); }
 }
 
 .grid { .card { margin: 0; } } //required to span cards 100%

--- a/src/sass/modules/css-grid/css-grid-mixins.scss
+++ b/src/sass/modules/css-grid/css-grid-mixins.scss
@@ -12,6 +12,13 @@
 	}
 }
 
+@mixin grid-column_desktop($span) {
+	@media #{$desktop} {
+		grid-column: span $span;
+		@supports(display: grid) { width: auto; }
+	}
+}
+
 %fallback-gap {
 	margin: $grid-gutter 0;
 	&:first-of-type, &:last-of-type { margin-top:    0; }

--- a/src/sass/modules/css-grid/css-grid-mixins.scss
+++ b/src/sass/modules/css-grid/css-grid-mixins.scss
@@ -4,6 +4,12 @@
 	}
 }
 
+@mixin fallback-grid_desktop($percent) {
+	@media #{$desktop} {
+		width: calc(#{$percent} - #{$grid-gutter}); float: left;//SAFARI 9
+	}
+}
+
 @mixin grid-column($span) {
 	grid-column: 1 / -1;
 	@media #{$tablet} {


### PR DESCRIPTION
Add `_desktop` to all CSS Grid classes to allow responsive adjustment.

@Nevren you might want to check my additions to your CSS Grid files. Also, could use your other Mac to test IE. :)

**Tablet**

<img width="712" alt="Screen Shot 2019-05-06 at 10 49 03 AM" src="https://user-images.githubusercontent.com/26393016/57237333-98eacb00-6fec-11e9-90ec-345ea953c5a1.png">

**Desktop**
<img width="809" alt="Screen Shot 2019-05-06 at 10 15 05 AM" src="https://user-images.githubusercontent.com/26393016/57237088-1104c100-6fec-11e9-840b-1ed344af445b.png">
