### PR TITLE
Move experimental file import

### DIFF
--- a/src/pages/templates/default.js
+++ b/src/pages/templates/default.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { Link } from 'gatsby'
 // The scss needs to be imported here for running 'gatsby build'
 import '../../sass/example-page/example-page.scss'
+import '../../sass/experimental/mobilemenu.scss'
+import '../../sass/experimental/placeholder.scss'
 
 export default () => (
 

--- a/src/sass/example-page/example-page.scss
+++ b/src/sass/example-page/example-page.scss
@@ -1,6 +1,6 @@
 $global-content-width: 800px !default;
 
-@import '../experimental/x-paragon.scss';
+@import '../paragon.scss';
 @import 'color';
 @import 'typography';
 @import 'image';


### PR DESCRIPTION
So we used to import the experimental files for the example pages. This caused some files to be double imported... moved this import to the default template.

Looks to have fixed it...