### PR TITLE
Add overpanel animation to component

### DIFF
--- a/src/pages/components/overpanel/code.js
+++ b/src/pages/components/overpanel/code.js
@@ -76,6 +76,20 @@ class OverpanelCode extends React.Component {
             </div>
             </div>
 
+            <h2 className="mt-space-xl" id="overpanelAnimation">Overpanel Animation
+              <Link to={location.pathname + "/#overpanelAnimation"} className="button button--transparent button--copy-link"></Link>
+            </h2>
+            <p className="no-margin">To add the sliding animation, all you need to do is apply an additional class <strong>AFTER</strong> <code className="example-text">overpanel</code>.</p>
+            <div className="example-container">
+              <div className="show-code">
+                <CodeToggle>
+{`<!-- Overpanel slides in from the bottom of the screen  -->
+<div class="overpanel slide-up">
+...`}
+                </CodeToggle>
+              </div>
+            </div>
+
           </div>
         </AppContent>
       </Layout>

--- a/src/pages/templates/overpanel-example.js
+++ b/src/pages/templates/overpanel-example.js
@@ -5,7 +5,7 @@ import '../../sass/example-page/example-page.scss'
 
 export default () => (
 
-	<div className="overpanel">
+	<div className="overpanel slide-up">
 		<header className="title-bar">
 			<div className="title-content">
 				<div>

--- a/src/sass/modules/overpanel/overpanel.scss
+++ b/src/sass/modules/overpanel/overpanel.scss
@@ -1,4 +1,20 @@
+@keyframes slideUp {
+  0% {
+    transform: translateY(100vh);
+  }
+  100% {
+    transform: none;
+  }
+}
 .overpanel {
+  position: fixed;
+  overflow-y: auto;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 3;
+  background-color: $gray-100;
 
   .title-bar {
     background-color: $white;
@@ -19,6 +35,11 @@
   .content {
     max-width: $content-s;
     margin-top: 0;
+  }
+
+  &.slide-up {
+    animation: slideUp 0.3s ease-in-out;
+    animation-fill-mode: both;
   }
 
   /* Utility classes for max-width of Overpanel */


### PR DESCRIPTION
Overpanel code did not have the slide up animation code. Added this and also called it out in the example page.

Also, with using the overpanel `position: fixed;` seemed to work better. This keeps the overpanel in view when the background content is longer then the overpanel.

<img width="795" alt="Screen Shot 2019-05-13 at 1 34 30 PM" src="https://user-images.githubusercontent.com/26393016/57645438-e4205300-7583-11e9-8df9-11ffb129a161.png">
