### PR TITLE
Overpanel, Loading Card, <a> tag adjustments

### DIFF
--- a/src/pages/components/cards/code.js
+++ b/src/pages/components/cards/code.js
@@ -158,7 +158,7 @@ export default class CardsCode extends React.Component {
               </div>
             </div>
 
-            <div className="card card--dashed">
+            <div className="card card--dashed mb-space-m">
               <div className="card-header">
                 <h3>Dashed</h3>
               </div>

--- a/src/pages/components/overpanel/code.js
+++ b/src/pages/components/overpanel/code.js
@@ -37,7 +37,7 @@ class OverpanelCode extends React.Component {
 <header class="title-bar">
   <div class="title-content">
     <div>
-      <h2>Overpanel Title</h2>
+      <h2 class="title">Overpanel Title</h2>
       <p>Overpanel description</p>
     </div>
     <a href="/templates/default">

--- a/src/pages/templates/overpanel-example.js
+++ b/src/pages/templates/overpanel-example.js
@@ -9,7 +9,7 @@ export default () => (
 		<header className="title-bar">
 			<div className="title-content">
 				<div>
-					<h2>Overpanel Title</h2>
+					<h2 className="title">Overpanel Title</h2>
 					<p>Overpanel description</p>
 				</div>
 				<Link to={"/components/overpanel/code"}>

--- a/src/sass/experimental/mobilemenu.scss
+++ b/src/sass/experimental/mobilemenu.scss
@@ -117,7 +117,7 @@ $sidebar-background: #354052;
   @extend .button--transparent;
   @extend .button--icon;
   @extend .button--white;
-  @media #{$tablet} { display: none; }
+  @media #{$tablet} { display: none !important; }
 }
 
 .mobile-profile{

--- a/src/sass/modules/accordion/_accordion.scss
+++ b/src/sass/modules/accordion/_accordion.scss
@@ -22,8 +22,16 @@
       &:before { color: $black; }
     }
 
-    .title { margin-left: $space-xs; }
-    .secondary-title { margin-left: auto; }
+    .title,
+    .secondary-title {
+      @media #{$phone} { font-size: $font-size-normal; }
+    }
+
+    .title { margin: 0 $space-xs; }
+    .secondary-title {
+      margin-left: auto;
+      white-space: nowrap;
+    }
 
     &:hover {
       background-color: $gray-50;

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -135,7 +135,7 @@
 
 //Set the margin of Cards when they are within a Grid
 .grid {
-  :not(.checkbox-card):not(.radio-card):not(.card-content) > .card {
+  :not(.checkbox-card):not(.radio-card):not(.card-content) > .card:not(.card--dashed) {
     @media #{$phone} {
       margin: 0 -#{$grid-gutter} $grid-gutter -#{$grid-gutter};
       border-radius: 0;

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -160,6 +160,7 @@
       background-color: $gray-100;
       border-radius: 3px;
       height: 1.25rem;
+      overflow: hidden;
 
       &::after {
         display: block;

--- a/src/sass/modules/overpanel/overpanel.scss
+++ b/src/sass/modules/overpanel/overpanel.scss
@@ -15,6 +15,7 @@
   left: 0;
   z-index: 3;
   background-color: $gray-100;
+  -webkit-overflow-scrolling: touch;
 
   .title-bar {
     background-color: $white;
@@ -29,6 +30,9 @@
       padding: $space-m;
       * { margin-bottom: 0; } //to overwrite global margin bottom
       button { white-space: nowrap; margin-left: $space-s; }
+    }
+    .title {
+      @media #{$phone} { font-size: $font-size-medium; }
     }
   }
 

--- a/src/sass/modules/typography/_typography.scss
+++ b/src/sass/modules/typography/_typography.scss
@@ -77,9 +77,10 @@ a {
     text-decoration: underline;
     text-decoration-color: inherit;
   }
-  
+
   &.button {
     text-decoration: none;
+    display: inline-block;
   }
 }
 


### PR DESCRIPTION
These styling bugs were noticed on mobile devices when doing device testing.

---

Fix loading card animation for mobile
- This looked weird, didn't like the `overflow: hidden;` on the `card-header`. Had to add it to each item.

Adjust overpanel styling on mobile
- Adjust header font size on smaller screen
- Fix mobile scrolling

Adjust Accordion title and subtitle font size on mobile

Make `<a>` tags with a `button` class inline-block