### PR TITLE
Add font weight 700

### DIFF
--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -1,6 +1,6 @@
 /* Imported font family
   ================================================== */
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600);
+@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700);
 
 /* Imported base components
   ================================================== */

--- a/src/sass/modules/typography/_typography.scss
+++ b/src/sass/modules/typography/_typography.scss
@@ -10,6 +10,7 @@ $font-size-xsmall:      0.8rem;   //14px
 
 $font-weight-normal:    400;
 $font-weight-semibold:  600;
+$font-weight-bold:      700;
 
 $font-family-header:    "Source Sans Pro", sans-serif;
 $font-family-body:      "Source Sans Pro", sans-serif;
@@ -101,4 +102,8 @@ ul.text-list {
 
 strong, .strong {
   font-weight: $font-weight-semibold;
+}
+
+.bold {
+  font-weight: $font-weight-bold;
 }


### PR DESCRIPTION
Wanted to add another level of hierarchy to our fonts. Not sure of the rules behind this bolder font yet, but seems like it could be useful for Page/Section Headers. To stand out a little more then our regular `strong` weight.

I am initially leaning towards suggesting `h1` and `h2` tags getting the `font-weight: 700;`
and then `h3`-`h6` getting the `font-weight: 600;`

Thoughts?

<img width="387" alt="Screen Shot 2019-06-12 at 10 02 18 AM" src="https://user-images.githubusercontent.com/26393016/59362794-b3097e80-8cf9-11e9-91aa-6237b7c69405.png">

