### PR TITLE
Fix Radio/Checkbox Button labels

### DIFF
--- a/src/sass/modules/forms/card-controls.scss
+++ b/src/sass/modules/forms/card-controls.scss
@@ -8,7 +8,7 @@ $card-checkbox--padding: 1rem !default; //Padding of checkbox
 .checkbox-card,
 .radio-card {
   display: inline-flex;
-  margin-right: 0.5rem;
+  margin: 0 $space-xs $space-xs 0;
 
   .card {
     float: none;

--- a/src/sass/modules/forms/forms.scss
+++ b/src/sass/modules/forms/forms.scss
@@ -229,6 +229,7 @@ fieldset {
   .checkbox-card {
     flex: 1 1 auto;
     -ms-flex: 1 1 auto;
+    margin-bottom: $space-xs;
 
     @media #{$tablet} {
       margin-right: 1rem;

--- a/src/sass/modules/forms/themed-elements.scss
+++ b/src/sass/modules/forms/themed-elements.scss
@@ -206,23 +206,6 @@ $switch--off: $gray-250 !default; //Color of switch when off
     }
   }
 
-  @-moz-document url-prefix() { //Target Firefox radio button
-    label:before {
-      font-size: 1.6rem;
-    }
-
-    @media #{$phone} {
-      label:not(.card) { //mobile-optimized large checkboxes if not inside a card-checkbox
-        &:before {
-          line-height: 20px;
-          padding: 0 7px;
-          font-size: 3rem;
-          height: 32px; width: 32px;
-        }
-      }
-    }
-  }
-
   //Radio Hover
   input:hover:not(:checked) ~ label { //Text Hover
     color: rgba($black, .6);

--- a/src/sass/modules/forms/themed-elements.scss
+++ b/src/sass/modules/forms/themed-elements.scss
@@ -23,6 +23,7 @@ $switch--off: $gray-250 !default; //Color of switch when off
 .checkbox--custom,
 .radio--custom {
   display: flex;
+  position: relative;
 
   input { // Places the input behind the label so it doesn't overlay text
     opacity: 0;
@@ -32,7 +33,7 @@ $switch--off: $gray-250 !default; //Color of switch when off
 
   label {
     @include user-select(none);
-    align-items: baseline;
+    align-items: center;
     cursor: pointer;
     display: inline-block;
     font-size: $font-size-normal;
@@ -72,6 +73,7 @@ $switch--off: $gray-250 !default; //Color of switch when off
       font-size: 12px;
       padding: 2px;
       text-indent: 0;
+      align-self: baseline;
     }
   }
 
@@ -84,7 +86,7 @@ $switch--off: $gray-250 !default; //Color of switch when off
         border-radius: 8px;
         font-size: 16px;
         height: 32px; width: 32px;
-        margin-top: 2px;
+        //margin-top: 2px;
         margin-right: 0.5rem;
         padding: 6px;
       }
@@ -181,12 +183,15 @@ $switch--off: $gray-250 !default; //Color of switch when off
     &:before {
       content: '•';
       border-radius: 50px;
-      font-size: 1.7rem;
-      line-height: 12px;
+      font-size: 1.6rem;
+      line-height: 11px;
       padding: 0 4px;
+      text-align: center;
       text-indent: 0;
+      align-self: flex-start;
 
-      @media #{$tablet} { font-size: 1.5rem; }
+      @media #{$tablet} { margin-top: 1px; }
+      @media #{$desktop} { line-height: 12px; }
     }
   }
 
@@ -194,8 +199,8 @@ $switch--off: $gray-250 !default; //Color of switch when off
     label:not(.card) { //mobile-optimized large radio buttons if not inside a card-radio
       &:before {
         font-size: 3rem;
-        line-height: 20px;
-        padding: 0 7px;
+        line-height: 19px;
+        padding: 0 6px;
         height: 32px; width: 32px;
       }
     }

--- a/src/sass/modules/forms/themed-elements.scss
+++ b/src/sass/modules/forms/themed-elements.scss
@@ -86,7 +86,6 @@ $switch--off: $gray-250 !default; //Color of switch when off
         border-radius: 8px;
         font-size: 16px;
         height: 32px; width: 32px;
-        //margin-top: 2px;
         margin-right: 0.5rem;
         padding: 6px;
       }


### PR DESCRIPTION
Fixes #51 
Fixes #77 

The labels were not aligning properly with the radio buttons. Also, the radio/checkbox cards were not stacking very nicely on mobile. Adjusted that as well. 

IE has the label wrapping under the radio button, but it looks like it does that right now.

---

**Broken Styles**
<img width="407" alt="Screen Shot 2019-06-13 at 11 35 57 AM" src="https://user-images.githubusercontent.com/26393016/59460826-95b1de80-8de5-11e9-8a5c-d290e9a4c2a0.png">
<img width="404" alt="Screen Shot 2019-06-13 at 11 36 10 AM" src="https://user-images.githubusercontent.com/26393016/59460827-95b1de80-8de5-11e9-81d9-42fb84044392.png">

---

**Fixed Styles**
<img width="421" alt="Screen Shot 2019-06-13 at 11 35 16 AM" src="https://user-images.githubusercontent.com/26393016/59460838-9ea2b000-8de5-11e9-864b-62b52470ed0e.png">
<img width="421" alt="Screen Shot 2019-06-13 at 11 35 42 AM" src="https://user-images.githubusercontent.com/26393016/59460839-9ea2b000-8de5-11e9-8fb7-429c65f18af5.png">

---

This has been devices tested across all devices and working well.