### PR TITLE
remove .no-wrap extension from flex tables

### DIFF
--- a/src/sass/modules/table/table.scss
+++ b/src/sass/modules/table/table.scss
@@ -32,7 +32,6 @@ $flex-table--border-color: $gray-50 !default;
         white-space: normal;
       }
       flex: 1 1 0;
-      @extend .no-wrap;
       padding-right: 0.5rem;
     }
   }


### PR DESCRIPTION
I think it would be better to let the custom classes dictate how the columns wrap