### PR TITLE
Card List plus React link

### DIFF
--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -86,11 +86,11 @@
     margin: 0;
     padding: 0;
     list-style: none;
-     li {
+    li {
       padding: $space-s $space-m;
       transition: $global-transition;
     }
-     &.is-selectable {
+    &.is-selectable {
       li {
         cursor: pointer;
         &:hover {
@@ -100,6 +100,12 @@
           margin: -#{$space-s} -#{$space-m};
           padding: $space-s $space-m;
         }
+      }
+    }
+    &.has-border {
+      li {
+        border-bottom: 1px solid $gray-100;
+        &:last-of-type { border: 0; }
       }
     }
   }

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -87,7 +87,7 @@
     padding: 0;
     list-style: none;
      li {
-      padding: 0.75rem;
+      padding: $space-s $space-m;
       transition: $global-transition;
     }
      &.is-selectable {
@@ -95,6 +95,10 @@
         cursor: pointer;
         &:hover {
           background-color: $gray-100;
+        }
+        a {
+          margin: -#{$space-s} -#{$space-m};
+          padding: $space-s $space-m;
         }
       }
     }

--- a/src/sass/modules/typography/_typography.scss
+++ b/src/sass/modules/typography/_typography.scss
@@ -82,6 +82,12 @@ a {
     text-decoration: none;
     display: inline-block;
   }
+  
+  &.no-decoration {
+    text-decoration: none;
+    color: $gray-900;
+    font-weight: $font-weight-normal;
+  }
 }
 
 p, li.text-list_item {


### PR DESCRIPTION
A selectable card list is setup to have the `li` be the link. But in React we add an `a` tag nested inside of the `li` tag to make it a link.

The added code will keep the padding consistent for both setups.

Also, added a utility class to remove the decoration that an `a` tag gets by default. For this use case... the `a` tag being a link for the entire row.