### PR TITLE
Update info card/card banner styles

### DIFF
--- a/src/pages/components/banner/code.js
+++ b/src/pages/components/banner/code.js
@@ -25,6 +25,8 @@ class BannerCode extends React.Component {
         <AppContent>
           <div className="grid grid-padding">
 
+            <p className="intro">Banners can be used to show important information to a user. Card banners should have text that is directly related to an action that has been completed or is about to be performed.</p>
+
             <h2 id="globalErrorBanner">Global Error Banner
               <Link to={location.pathname + "/#globalErrorBanner"} className="button button--transparent button--copy-link"></Link>
             </h2>
@@ -70,9 +72,10 @@ class BannerCode extends React.Component {
             </div>
 
 
-              <h2 id="defaultCardBanner">Default Card Banner
+              <h2 className="mt-space-xl" id="defaultCardBanner">Default Card Banner
                 <Link to={location.pathname + "/#defaultCardBanner"} className="button button--transparent button--copy-link"></Link>
               </h2>
+              <p>Add the class <code className="example-text">.has-icon</code> to <code className="example-text">.card-header</code> when using an icon.</p>
               <div className="example-container">
                 <div className="card">
                   <div className="card-header has-border">
@@ -131,8 +134,8 @@ class BannerCode extends React.Component {
                   </div>
                 </div>
                 <CodeToggle>
-{`<div class="card-info has-success">
-  <div class="card-header has-icon no-margin">
+{`<div class="card-info has-success no-margin">
+  <div class="card-header has-icon">
     <i class="dashing-icon dashing-icon--checkmark-filled" />
     <h4 class="card-info--title">Success</h4>
   </div>
@@ -218,6 +221,7 @@ class BannerCode extends React.Component {
               <h2 className="mt-space-xl" id="cardBannerWithButton">Card Banner without header
                 <Link to={location.pathname + "/#cardBannerWithButton"} className="button button--transparent button--copy-link"></Link>
               </h2>
+              <p>Add the class <code className="example-text">.has-icon</code> to <code className="example-text">.card-content</code> when using an icon.</p>
               <div className="example-container">
                 <div className="card">
                   <div className="card-header has-border">
@@ -236,7 +240,8 @@ class BannerCode extends React.Component {
                   </div>
                 </div>
                 <CodeToggle>
-{`<div class="card-info no-margin">
+{`<!-- .has-icon is added to .card-content to give appropriate display and spacing -->
+<div class="card-info no-margin">
   <div class="card-content has-icon">
     <i class="dashing-icon dashing-icon--alert-filled" />
     <p class="no-margin">This is an error card with a icon.</p>

--- a/src/pages/components/banner/code.js
+++ b/src/pages/components/banner/code.js
@@ -75,12 +75,18 @@ class BannerCode extends React.Component {
               </h2>
               <div className="example-container">
                 <div className="card">
-                  <div className="card-header">
+                  <div className="card-header has-border">
                     <h3>Default Banner</h3>
                   </div>
                   <div className="card-content">
-                    <div className="card-banner">
-                      <p>This is a card banner</p>
+                    <div className="card-info no-margin">
+                      <div className="card-header has-icon">
+                        <i className="dashing-icon dashing-icon--info-filled" />
+                        <h4 className="card-info--title">Please Note</h4>
+                      </div>
+                      <div className="card-content">
+                        <p className="no-margin">This is an info card.</p>
+                      </div>
                     </div>
                   </div>
                   <div className="card-footer">
@@ -88,17 +94,13 @@ class BannerCode extends React.Component {
                   </div>
                 </div>
                 <CodeToggle>
-{`<div class="card">
-  <div class="card-header">
-    <h3>Default Banner</h3>
+{`<div class="card-info no-margin">
+  <div class="card-header has-icon">
+    <i class="dashing-icon dashing-icon--info-filled" />
+    <h4 class="card-info--title">Please Note</h4>
   </div>
   <div class="card-content">
-    <div class="card-banner">
-      <p>This is a card banner</p>
-    </div>
-  </div>
-  <div class="card-footer">
-    <p>Use a banner within a card to display additional context</p>
+    <p class="no-margin">This is an info card.</p>
   </div>
 </div>`}
                 </CodeToggle>
@@ -110,13 +112,18 @@ class BannerCode extends React.Component {
               </h2>
               <div className="example-container">
                 <div className="card">
-                  <div className="card-header">
+                  <div className="card-header has-border">
                     <h3>Success Banner</h3>
                   </div>
                   <div className="card-content">
-                    <div className="card-banner has-success">
-                      <i className="dashing-icon dashing-icon--checkmark-filled"></i>
-                      <p>Your file is ready to upload</p>
+                    <div className="card-info has-success no-margin">
+                      <div className="card-header has-icon">
+                        <i className="dashing-icon dashing-icon--checkmark-filled" />
+                        <h4 className="card-info--title">Success</h4>
+                      </div>
+                      <div className="card-content">
+                        <p className="no-margin">This is a success card.</p>
+                      </div>
                     </div>
                   </div>
                   <div className="card-footer">
@@ -124,18 +131,13 @@ class BannerCode extends React.Component {
                   </div>
                 </div>
                 <CodeToggle>
-{`<div class="card">
-  <div class="card-header">
-    <h3>Success Banner</h3>
+{`<div class="card-info has-success">
+  <div class="card-header has-icon no-margin">
+    <i class="dashing-icon dashing-icon--checkmark-filled" />
+    <h4 class="card-info--title">Success</h4>
   </div>
   <div class="card-content">
-    <div class="card-banner has-success">
-      <i class="dashing-icon dashing-icon--checkmark-filled"></i>
-      <p>Your file is ready to upload</p>
-    </div>
-  </div>
-  <div class="card-footer">
-    <p>Use success banners to notify users of a successful action.</p>
+    <p class="no-margin">This is a success card.</p>
   </div>
 </div>`}
                 </CodeToggle>
@@ -146,13 +148,18 @@ class BannerCode extends React.Component {
               </h2>
               <div className="example-container">
                 <div className="card">
-                  <div className="card-header">
+                  <div className="card-header has-border">
                     <h3>Warning Banner</h3>
                   </div>
                   <div className="card-content">
-                    <div className="card-banner has-warning">
-                      <i className="dashing-icon dashing-icon--info-filled"></i>
-                      <p>You may only submit bill information and upload images for one statement at a time. If you have multiple statements to submit, please enter them separately.</p>
+                    <div className="card-info has-warning no-margin">
+                      <div className="card-header has-icon">
+                        <i className="dashing-icon dashing-icon--alert-filled" />
+                        <h4 className="card-info--title">Warning</h4>
+                      </div>
+                      <div className="card-content">
+                        <p className="no-margin">This is a warning card.</p>
+                      </div>
                     </div>
                   </div>
                   <div className="card-footer">
@@ -160,18 +167,13 @@ class BannerCode extends React.Component {
                   </div>
                 </div>
                 <CodeToggle>
-{`<div class="card">
-  <div class="card-header">
-    <h3>Warning Banner</h3>
+{`<div class="card-info has-warning no-margin">
+  <div class="card-header has-icon">
+    <i class="dashing-icon dashing-icon--alert-filled" />
+    <h4 class="card-info--title">Warning</h4>
   </div>
   <div class="card-content">
-    <div class="card-banner has-warning">
-      <i class="dashing-icon dashing-icon--info-filled"></i>
-      <p>You may only submit bill information and upload images for one statement at a time. If you have multiple statements to submit, please enter them separately.</p>
-    </div>
-  </div>
-  <div class="card-footer">
-    <p>Use warning banners to inform your user of potential errors.</p>
+    <p class="no-margin">This is a warning card.</p>
   </div>
 </div>`}
                 </CodeToggle>
@@ -182,13 +184,18 @@ class BannerCode extends React.Component {
               </h2>
               <div className="example-container">
                 <div className="card">
-                  <div className="card-header">
+                  <div className="card-header has-border">
                     <h3>Error Banner</h3>
                   </div>
                   <div className="card-content">
-                    <div className="card-banner has-error">
-                      <i className="dashing-icon dashing-icon--alert-filled"></i>
-                      <p>You must complete all fields below before continuing</p>
+                    <div className="card-info has-error no-margin">
+                      <div className="card-header has-icon">
+                        <i className="dashing-icon dashing-icon--alert-filled" />
+                        <h4 className="card-info--title">Error</h4>
+                      </div>
+                      <div className="card-content">
+                        <p className="no-margin">This is a error card.</p>
+                      </div>
                     </div>
                   </div>
                   <div className="card-footer">
@@ -196,18 +203,43 @@ class BannerCode extends React.Component {
                   </div>
                 </div>
                 <CodeToggle>
-{`<div class="card">
-  <div class="card-header">
-    <h3>Error Banner</h3>
+{`<div class="card-info has-error no-margin">
+  <div class="card-header has-icon">
+    <i class="dashing-icon dashing-icon--alert-filled" />
+    <h4 class="card-info--title">Error</h4>
   </div>
   <div class="card-content">
-    <div class="card-banner has-error">
-      <i class="dashing-icon dashing-icon--alert-filled"></i>
-      <p>You must complete all fields below before continuing</p>
-    </div>
+    <p class="no-margin">This is a error card.</p>
   </div>
-  <div class="card-footer">
-    <p>Use error banners to display critical and important information to your user after they have performed an action.</p>
+</div>`}
+                </CodeToggle>
+              </div>
+
+              <h2 className="mt-space-xl" id="cardBannerWithButton">Card Banner without header
+                <Link to={location.pathname + "/#cardBannerWithButton"} className="button button--transparent button--copy-link"></Link>
+              </h2>
+              <div className="example-container">
+                <div className="card">
+                  <div className="card-header has-border">
+                    <h3>Banner without header</h3>
+                  </div>
+                  <div className="card-content">
+                    <div className="card-info no-margin">
+                      <div className="card-content has-icon">
+                        <i class="dashing-icon dashing-icon--alert-filled" />
+                        <p className="no-margin">This is an error card with a icon.</p>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="card-footer">
+                    <p>Card banners can be used without a title when that additional information is not needed.</p>
+                  </div>
+                </div>
+                <CodeToggle>
+{`<div class="card-info no-margin">
+  <div class="card-content has-icon">
+    <i class="dashing-icon dashing-icon--alert-filled" />
+    <p class="no-margin">This is an error card with a icon.</p>
   </div>
 </div>`}
                 </CodeToggle>
@@ -218,13 +250,15 @@ class BannerCode extends React.Component {
               </h2>
               <div className="example-container">
                 <div className="card">
-                  <div className="card-header">
+                  <div className="card-header has-border">
                     <h3>Banner with Button</h3>
                   </div>
                   <div className="card-content">
-                    <div className="card-banner has-button">
-                      <p>This is a card banner</p>
-                      <button type="button" className="button button--border button--gray button--smooth" style={{ marginLeft: "auto" }}>Learn More</button>
+                    <div className="card-info no-margin">
+                      <div className="card-content has-button">
+                        <p className="no-margin">This is a card banner</p>
+                        <button type="button" className="button button--border button--blue button--smooth" style={{ marginLeft: "auto" }}>Learn More</button>
+                      </div>
                     </div>
                   </div>
                   <div className="card-footer">
@@ -237,47 +271,15 @@ class BannerCode extends React.Component {
     <h3>Banner with Button</h3>
   </div>
   <div class="card-content">
-    <div class="card-banner has-button">
-      <p>This is a card banner</p>
-      <button type="button" class="button button--border button--gray button--smooth" style="margin-left: auto;">Learn More</button>
+    <div class="card-info no-margin">
+      <div class="card-content has-button">
+        <p class="no-margin">This is a card banner</p>
+        <button type="button" class="button button--border button--blue button--smooth" style={{ marginLeft: "auto" }}>Learn More</button>
+      </div>
     </div>
   </div>
   <div class="card-footer">
     <p>Use a banner within a card to display additional context. If you have a button make sure to add <code class="example-text">.has-button</code> to reduce the padding.</p>
-  </div>
-</div>`}
-                </CodeToggle>
-              </div>
-
-              <h2 className="mt-space-xl" id="cardBannerWithLink">Card Banner with link
-                <Link to={location.pathname + "/#cardBannerWithLink"} className="button button--transparent button--copy-link"></Link>
-              </h2>
-              <div className="example-container">
-                <div className="card">
-                  <div className="card-header">
-                    <h3>Banner with Link</h3>
-                  </div>
-                  <div className="card-content">
-                    <div className="card-banner">
-                      <p>This is a card banner with <Link to="components/banner/code">link here</Link></p>
-                    </div>
-                  </div>
-                  <div className="card-footer">
-                    <p>Links within in <code className="example-text">.card-banner</code> get an underline border and transition.</p>
-                  </div>
-                </div>
-                <CodeToggle>
-{`<div class="card">
-  <div class="card-header">
-    <h3>Banner with Link</h3>
-  </div>
-  <div class="card-content">
-    <div class="card-banner">
-      <p>This is a card banner with <a>link here</a></p>
-    </div>
-  </div>
-  <div class="card-footer">
-    <p>Links within in <code class="example-text">.card-banner</code> get an underline border and transition.</p>
   </div>
 </div>`}
                 </CodeToggle>

--- a/src/pages/components/banner/code.js
+++ b/src/pages/components/banner/code.js
@@ -88,7 +88,7 @@ class BannerCode extends React.Component {
                         <h4 className="card-info--title">Please Note</h4>
                       </div>
                       <div className="card-content">
-                        <p className="no-margin">This is an info card.</p>
+                        <p className="no-margin">This is an info card banner.</p>
                       </div>
                     </div>
                   </div>
@@ -103,7 +103,7 @@ class BannerCode extends React.Component {
     <h4 class="card-info--title">Please Note</h4>
   </div>
   <div class="card-content">
-    <p class="no-margin">This is an info card.</p>
+    <p class="no-margin">This is an info card banner.</p>
   </div>
 </div>`}
                 </CodeToggle>
@@ -125,7 +125,7 @@ class BannerCode extends React.Component {
                         <h4 className="card-info--title">Success</h4>
                       </div>
                       <div className="card-content">
-                        <p className="no-margin">This is a success card.</p>
+                        <p className="no-margin">This is a success card banner.</p>
                       </div>
                     </div>
                   </div>
@@ -140,7 +140,7 @@ class BannerCode extends React.Component {
     <h4 class="card-info--title">Success</h4>
   </div>
   <div class="card-content">
-    <p class="no-margin">This is a success card.</p>
+    <p class="no-margin">This is a success card banner.</p>
   </div>
 </div>`}
                 </CodeToggle>
@@ -161,7 +161,7 @@ class BannerCode extends React.Component {
                         <h4 className="card-info--title">Warning</h4>
                       </div>
                       <div className="card-content">
-                        <p className="no-margin">This is a warning card.</p>
+                        <p className="no-margin">This is a warning card banner.</p>
                       </div>
                     </div>
                   </div>
@@ -176,7 +176,7 @@ class BannerCode extends React.Component {
     <h4 class="card-info--title">Warning</h4>
   </div>
   <div class="card-content">
-    <p class="no-margin">This is a warning card.</p>
+    <p class="no-margin">This is a warning card banner.</p>
   </div>
 </div>`}
                 </CodeToggle>
@@ -197,7 +197,7 @@ class BannerCode extends React.Component {
                         <h4 className="card-info--title">Error</h4>
                       </div>
                       <div className="card-content">
-                        <p className="no-margin">This is a error card.</p>
+                        <p className="no-margin">This is a error card banner.</p>
                       </div>
                     </div>
                   </div>
@@ -212,7 +212,7 @@ class BannerCode extends React.Component {
     <h4 class="card-info--title">Error</h4>
   </div>
   <div class="card-content">
-    <p class="no-margin">This is a error card.</p>
+    <p class="no-margin">This is a error card banner.</p>
   </div>
 </div>`}
                 </CodeToggle>
@@ -231,7 +231,7 @@ class BannerCode extends React.Component {
                     <div className="card-info no-margin">
                       <div className="card-content has-icon">
                         <i class="dashing-icon dashing-icon--alert-filled" />
-                        <p className="no-margin">This is an error card with a icon.</p>
+                        <p className="no-margin">This is an error card banner with a icon.</p>
                       </div>
                     </div>
                   </div>
@@ -244,7 +244,7 @@ class BannerCode extends React.Component {
 <div class="card-info no-margin">
   <div class="card-content has-icon">
     <i class="dashing-icon dashing-icon--alert-filled" />
-    <p class="no-margin">This is an error card with a icon.</p>
+    <p class="no-margin">This is an error card banner with a icon.</p>
   </div>
 </div>`}
                 </CodeToggle>

--- a/src/pages/components/banner/guidelines.js
+++ b/src/pages/components/banner/guidelines.js
@@ -23,20 +23,32 @@ export default () => (
             <p>Common types of card banners are success, warning, error, and generic. Like <Link to="/components/actions/guidelines">Actions</Link>, banners should use purposeful color when using them.</p>
             <div className="image-container double-padding">
               <div className="banner-container">
-                <div className="card-banner">
-                  <p>This is a card banner</p>
+                <div className="card-info no-margin--top">
+                  <div className="card-content has-icon">
+                    <i className="dashing-icon dashing-icon--info-filled" />
+                    <p className="no-margin">This is an info card.</p>
+                  </div>
                 </div>
-                <div className="card-banner has-success">
-                  <i className="dashing-icon dashing-icon--checkmark-filled"></i>
-                  <p>Your file is ready to upload</p>
+
+                <div className="card-info has-success no-margin--top">
+                  <div className="card-content has-icon">
+                    <i className="dashing-icon dashing-icon--checkmark-filled" />
+                    <p className="no-margin">This is a success card.</p>
+                  </div>
                 </div>
-                <div className="card-banner has-warning">
-                  <i className="dashing-icon dashing-icon--info-filled"></i>
-                  <p>You may only submit bill information and upload images for one statement at a time. If you have multiple statements to submit, please enter them separately.</p>
+
+                <div className="card-info has-warning no-margin--top">
+                  <div className="card-content has-icon">
+                    <i className="dashing-icon dashing-icon--alert-filled" />
+                    <p className="no-margin">This is a warning card.</p>
+                  </div>
                 </div>
-                <div className="card-banner has-error">
-                  <i className="dashing-icon dashing-icon--alert-filled"></i>
-                  <p>You must complete all fields below before continuing</p>
+
+                <div className="card-info has-error no-margin">
+                  <div className="card-content has-icon">
+                    <i className="dashing-icon dashing-icon--alert-filled" />
+                    <p className="no-margin">This is a error card.</p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -47,15 +59,18 @@ export default () => (
             </blockquote>
 
             <h2 className="has-number has-number--two">Placement</h2>
-            <p>When using a card banner, it should be placed directly under the card header to draw the user's attention right away.</p>
+            <p>When using a card banner, it can be placed directly under the card header to draw the user's attention right away or close to the action that was just completed.</p>
             <div className="image-container double-padding" style={{ marginBottom: "2rem" }}>
               <div className="card card--example-titles">
-                <div className="card-header">
+                <div className="card-header has-border">
                   <h3>Membership Options</h3>
                 </div>
                 <div className="card-content">
-                  <div className="card-banner">
-                    <p>This is a card banner</p>
+                  <div className="card-info has-error no-margin">
+                    <div className="card-content has-icon">
+                      <i className="dashing-icon dashing-icon--alert-filled" />
+                      <p className="no-margin">There was an error saving your Membership information.</p>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/pages/components/cards/code.js
+++ b/src/pages/components/cards/code.js
@@ -401,7 +401,7 @@ export default class CardsCode extends React.Component {
 
               <p className="mb-space-m">Information cards are nested inside another card and are a good way to spotlight instructions or to give text more emphasis.</p>
 
-              <div className="card card-info">
+              <div className="card card-info mb-space-m">
                 <div className="card-header has-icon">
                   <i className="dashing-icon dashing-icon--info-filled dashing-icon--black" />
                   <h4>Default Info Card</h4>
@@ -411,14 +411,52 @@ export default class CardsCode extends React.Component {
                 </div>
               </div>
 
-              <div className="card card-info--gray mt-space-m">
+              <div className="error-card mb-space-m">
+                <div className="flex flex-baseline has-icon p-space-m">
+                  <i className="dashing-icon dashing-icon--alert-filled dashing-icon--red" />
+                  <p className="strong no-margin">This is an info card with an icon.</p>
+                </div>
+              </div>
+
+              <div className="error-card-2 mb-space-m">
+                <div className="flex flex-baseline has-icon p-space-m">
+                  <i className="dashing-icon dashing-icon--alert-filled dashing-icon--red" />
+                  <p className="no-margin">This is an error info card.</p>
+                </div>
+              </div>
+
+              <div className="card error-card-3 mb-space-m">
+                <div className="card-header flex flex-baseline has-icon">
+                  <i className="dashing-icon dashing-icon--alert-filled dashing-icon--red" />
+                  <h4 className="text-color--red no-margin">Important</h4>
+                </div>
+                <p className="card-content no-margin">This is an error info card.</p>
+              </div>
+
+              <div className="card warning-card-3 mb-space-m">
+                <div className="card-header flex flex-baseline has-icon">
+                  <i className="dashing-icon dashing-icon--alert-filled" />
+                  <h4 className="text-color--orange no-margin">Warning</h4>
+                </div>
+                <p className="card-content no-margin">This is an warning info card.</p>
+              </div>
+
+              <div className="card info-card-3">
+                <div className="card-header flex flex-baseline has-icon">
+                  <i className="dashing-icon dashing-icon--info-filled" />
+                  <h4 className="text-color--blue no-margin">Information</h4>
+                </div>
+                <p className="card-content no-margin">This is an info card.</p>
+              </div>
+
+              {/* <div className="card card-info--gray mt-space-m">
                 <div className="card-header">
                   <h4>Gray Info Card</h4>
                 </div>
                 <div className="card-content">
                   <p className="no-margin">This is a gray info card.</p>
                 </div>
-              </div>
+              </div> */}
 
             </div>
 

--- a/src/pages/components/cards/code.js
+++ b/src/pages/components/cards/code.js
@@ -399,115 +399,75 @@ export default class CardsCode extends React.Component {
             </div>
             <div className="card-content">
 
-              {/* <p className="mb-space-m">Information cards are nested inside another card and are a good way to spotlight instructions or to give text more emphasis.</p> */}
+              <p className="mb-space-m">Information cards are nested inside another card and are a good way to spotlight instructions or to give text more emphasis.</p>
 
-              <div className="card card-info mb-space-xl">
-                <div className="card-header has-icon">
-                  <i className="dashing-icon dashing-icon--info-filled dashing-icon--black" />
-                  <h4>Default Info Card</h4>
-                </div>
-                <div className="card-content">
-                  <p className="no-margin">This is an info card with an icon.</p>
-                </div>
-              </div>
-
-              <div className="card error-card-3 has-info mb-space-m">
-                <div className="card-header flex flex-baseline has-icon">
+              <div className="card-info has-info">
+                <div className="card-header flex has-icon">
                   <i className="dashing-icon dashing-icon--info-filled" />
                   <h4 className="text-color--blue no-margin">Please Note</h4>
                 </div>
                 <p className="card-content no-margin">This is an info card.</p>
               </div>
 
-              <div className="card error-card-3 has-warning mb-space-m">
-                <div className="card-header flex flex-baseline has-icon">
+              <div className="card-info has-success">
+                <div className="card-header flex has-icon">
+                  <i className="dashing-icon dashing-icon--checkmark-filled" />
+                  <h4 className="text-color--green no-margin">Success</h4>
+                </div>
+                <p className="card-content no-margin">This is an success info card.</p>
+              </div>
+
+              <div className="card-info has-warning">
+                <div className="card-header flex has-icon">
                   <i className="dashing-icon dashing-icon--alert-filled" />
                   <h4 className="text-color--orange no-margin">Warning</h4>
                 </div>
                 <p className="card-content no-margin">This is an warning info card.</p>
               </div>
 
-              <div className="card error-card-3 has-error mb-space-xl">
-                <div className="card-header flex flex-baseline has-icon">
+              <div className="card-info has-error">
+                <div className="card-header flex has-icon">
                   <i className="dashing-icon dashing-icon--alert-filled" />
-                  <h4 className="text-color--red no-margin">Important</h4>
+                  <h4 className="text-color--red no-margin">Error</h4>
                 </div>
                 <p className="card-content no-margin">This is an error info card.</p>
               </div>
-
-              <div className="card error-card-4 has-info mb-space-m">
-                <div className="card-header flex flex-baseline has-icon">
-                  <i className="dashing-icon dashing-icon--alert-filled" />
-                  <h4 className="text-color--blue no-margin">Please Note</h4>
-                </div>
-                <p className="card-content no-margin">This is an error info card.</p>
-              </div>
-
-              <div className="card error-card-4 has-warning mb-space-m">
-                <div className="card-header flex flex-baseline has-icon">
-                  <i className="dashing-icon dashing-icon--alert-filled" />
-                  <h4 className="text-color--orange no-margin">Warning</h4>
-                </div>
-                <p className="card-content no-margin">This is an error info card.</p>
-              </div>
-
-              <div className="card error-card-4 has-error mb-space-m">
-                <div className="card-header flex flex-baseline has-icon">
-                  <i className="dashing-icon dashing-icon--alert-filled dashing-icon--red" />
-                  <h4 className="text-color--red no-margin">Important</h4>
-                </div>
-                <p className="card-content no-margin">This is an error info card.</p>
-              </div>
-
-              {/* <div className="card warning-card-3 mb-space-m">
-                <div className="card-header flex flex-baseline has-icon">
-                  <i className="dashing-icon dashing-icon--alert-filled" />
-                  <h4 className="text-color--orange no-margin">Warning</h4>
-                </div>
-                <p className="card-content no-margin">This is an warning info card.</p>
-              </div>
-
-              <div className="card info-card-3">
-                <div className="card-header flex flex-baseline has-icon">
-                  <i className="dashing-icon dashing-icon--info-filled" />
-                  <h4 className="text-color--blue no-margin">Information</h4>
-                </div>
-                <p className="card-content no-margin">This is an info card.</p>
-              </div> */}
-
-              {/* <div className="card card-info--gray mt-space-m">
-                <div className="card-header">
-                  <h4>Gray Info Card</h4>
-                </div>
-                <div className="card-content">
-                  <p className="no-margin">This is a gray info card.</p>
-                </div>
-              </div> */}
 
             </div>
 
           </div>
 
           <CodeToggle>
-{`<div class="card-content">
-  <div class="card card-info">
-    <div class="card-header has-icon">
-      <i class="dashing-icon dashing-icon--info-filled dashing-icon--black" />
-      <h4>Default Info Card</h4>
-    </div>
-    <div class="card-content">
-      <p class="no-margin">This is an info card with an icon.</p>
-    </div>
+{`<div class="card-info has-info">
+  <div class="card-header flex has-icon">
+    <i class="dashing-icon dashing-icon--info-filled"></i>
+    <h4 class="text-color--blue no-margin">Please Note</h4>
   </div>
+  <p class="card-content no-margin">This is an info card.</p>
+</div>
 
-  <div class="card card-info--gray">
-    <div class="card-header">
-      <h4>Gray Info Card</h4>
-    </div>
-    <div class="card-content">
-      <p class="no-margin">This is a gray info card.</p>
-    </div>
+<div class="card-info has-success">
+  <div class="card-header flex has-icon">
+    <i class="dashing-icon dashing-icon--checkmark-filled"></i>
+    <h4 class="text-color--green no-margin">Success</h4>
   </div>
+  <p class="card-content no-margin">This is an success info card.</p>
+</div>
+
+<div class="card-info has-warning">
+  <div class="card-header flex has-icon">
+    <i class="dashing-icon dashing-icon--alert-filled"></i>
+    <h4 class="text-color--orange no-margin">Warning</h4>
+  </div>
+  <p class="card-content no-margin">This is an warning info card.</p>
+</div>
+
+<div class="card-info has-error">
+  <div class="card-header flex has-icon">
+    <i class="dashing-icon dashing-icon--alert-filled"></i>
+    <h4 class="text-color--red no-margin">Error</h4>
+  </div>
+  <p class="card-content no-margin">This is an error info card.</p>
 </div>
 `}
           </CodeToggle>

--- a/src/pages/components/cards/code.js
+++ b/src/pages/components/cards/code.js
@@ -401,36 +401,51 @@ export default class CardsCode extends React.Component {
 
               <p className="mb-space-m">Information cards are nested inside another card and are a good way to spotlight instructions or to give text more emphasis.</p>
 
-              <div className="card-info has-info">
-                <div className="card-header flex has-icon">
+              <div className="card-info">
+                <div className="card-header has-icon">
                   <i className="dashing-icon dashing-icon--info-filled" />
-                  <h4 className="text-color--blue no-margin">Please Note</h4>
+                  <h4 className="card-info--title">Please Note</h4>
                 </div>
-                <p className="card-content no-margin">This is an info card.</p>
+                <div className="card-content">
+                  <p className="no-margin">This is an info card.</p>
+                </div>
               </div>
 
               <div className="card-info has-success">
-                <div className="card-header flex has-icon">
+                <div className="card-header has-icon">
                   <i className="dashing-icon dashing-icon--checkmark-filled" />
-                  <h4 className="text-color--green no-margin">Success</h4>
+                  <h4 className="card-info--title">Success</h4>
                 </div>
-                <p className="card-content no-margin">This is an success info card.</p>
+                <div className="card-content">
+                  <p className="no-margin">This is a success card.</p>
+                </div>
               </div>
 
               <div className="card-info has-warning">
-                <div className="card-header flex has-icon">
+                <div className="card-header has-icon">
                   <i className="dashing-icon dashing-icon--alert-filled" />
-                  <h4 className="text-color--orange no-margin">Warning</h4>
+                  <h4 className="card-info--title">Warning</h4>
                 </div>
-                <p className="card-content no-margin">This is an warning info card.</p>
+                <div className="card-content">
+                  <p className="no-margin">This is a warning card.</p>
+                </div>
               </div>
 
               <div className="card-info has-error">
-                <div className="card-header flex has-icon">
+                <div className="card-header has-icon">
                   <i className="dashing-icon dashing-icon--alert-filled" />
-                  <h4 className="text-color--red no-margin">Error</h4>
+                  <h4 className="card-info--title">Error</h4>
                 </div>
-                <p className="card-content no-margin">This is an error info card.</p>
+                <div className="card-content">
+                  <p className="no-margin">This is a error card.</p>
+                </div>
+              </div>
+
+              <div className="card-info has-error">
+                <div className="card-content has-icon">
+                  <i className="dashing-icon dashing-icon--alert-filled" />
+                  <p className="no-margin">This is a error card without a title.</p>
+                </div>
               </div>
 
             </div>
@@ -439,35 +454,51 @@ export default class CardsCode extends React.Component {
 
           <CodeToggle>
 {`<div class="card-info has-info">
-  <div class="card-header flex has-icon">
+  <div class="card-header has-icon">
     <i class="dashing-icon dashing-icon--info-filled"></i>
-    <h4 class="text-color--blue no-margin">Please Note</h4>
+    <h4 class="card-info--title">Please Note</h4>
   </div>
-  <p class="card-content no-margin">This is an info card.</p>
+  <div class="card-content">
+    <p class="no-margin">This is an info card.</p>
+  </div>
 </div>
 
 <div class="card-info has-success">
-  <div class="card-header flex has-icon">
+  <div class="card-header has-icon">
     <i class="dashing-icon dashing-icon--checkmark-filled"></i>
-    <h4 class="text-color--green no-margin">Success</h4>
+    <h4 class="card-info--title">Success</h4>
   </div>
-  <p class="card-content no-margin">This is an success info card.</p>
+  <div class="card-content">
+    <p class="no-margin">This is a success card.</p>
+  </div>
 </div>
 
 <div class="card-info has-warning">
-  <div class="card-header flex has-icon">
+  <div class="card-header has-icon">
     <i class="dashing-icon dashing-icon--alert-filled"></i>
-    <h4 class="text-color--orange no-margin">Warning</h4>
+    <h4 class="card-info--title">Warning</h4>
   </div>
-  <p class="card-content no-margin">This is an warning info card.</p>
+  <div class="card-content">
+    <p class="no-margin">This is a warning card.</p>
+  </div>
 </div>
 
 <div class="card-info has-error">
-  <div class="card-header flex has-icon">
+  <div class="card-header has-icon">
     <i class="dashing-icon dashing-icon--alert-filled"></i>
-    <h4 class="text-color--red no-margin">Error</h4>
+    <h4 class="card-info--title">Error</h4>
   </div>
-  <p class="card-content no-margin">This is an error info card.</p>
+  <div class="card-content">
+    <p class="no-margin">This is a error card.</p>
+  </div>
+</div>
+
+<!-- Error card without a title -->
+<div class="card-info has-error">
+  <div class="card-content has-icon">
+    <i class="dashing-icon dashing-icon--alert-filled" />
+    <p class="no-margin">This is a error card without a title.</p>
+  </div>
 </div>
 `}
           </CodeToggle>

--- a/src/pages/components/cards/code.js
+++ b/src/pages/components/cards/code.js
@@ -394,14 +394,14 @@ export default class CardsCode extends React.Component {
         <div className="example-container">
 
           <div className="card">
-            <div className="card-header">
+            <div className="card-header has-border">
               <h3>Information Cards</h3>
             </div>
             <div className="card-content">
 
-              <p className="mb-space-m">Information cards are nested inside another card and are a good way to spotlight instructions or to give text more emphasis.</p>
+              {/* <p className="mb-space-m">Information cards are nested inside another card and are a good way to spotlight instructions or to give text more emphasis.</p> */}
 
-              <div className="card card-info mb-space-m">
+              <div className="card card-info mb-space-xl">
                 <div className="card-header has-icon">
                   <i className="dashing-icon dashing-icon--info-filled dashing-icon--black" />
                   <h4>Default Info Card</h4>
@@ -411,21 +411,47 @@ export default class CardsCode extends React.Component {
                 </div>
               </div>
 
-              <div className="error-card mb-space-m">
-                <div className="flex flex-baseline has-icon p-space-m">
-                  <i className="dashing-icon dashing-icon--alert-filled dashing-icon--red" />
-                  <p className="strong no-margin">This is an info card with an icon.</p>
+              <div className="card error-card-3 has-info mb-space-m">
+                <div className="card-header flex flex-baseline has-icon">
+                  <i className="dashing-icon dashing-icon--info-filled" />
+                  <h4 className="text-color--blue no-margin">Please Note</h4>
                 </div>
+                <p className="card-content no-margin">This is an info card.</p>
               </div>
 
-              <div className="error-card-2 mb-space-m">
-                <div className="flex flex-baseline has-icon p-space-m">
-                  <i className="dashing-icon dashing-icon--alert-filled dashing-icon--red" />
-                  <p className="no-margin">This is an error info card.</p>
+              <div className="card error-card-3 has-warning mb-space-m">
+                <div className="card-header flex flex-baseline has-icon">
+                  <i className="dashing-icon dashing-icon--alert-filled" />
+                  <h4 className="text-color--orange no-margin">Warning</h4>
                 </div>
+                <p className="card-content no-margin">This is an warning info card.</p>
               </div>
 
-              <div className="card error-card-3 mb-space-m">
+              <div className="card error-card-3 has-error mb-space-xl">
+                <div className="card-header flex flex-baseline has-icon">
+                  <i className="dashing-icon dashing-icon--alert-filled" />
+                  <h4 className="text-color--red no-margin">Important</h4>
+                </div>
+                <p className="card-content no-margin">This is an error info card.</p>
+              </div>
+
+              <div className="card error-card-4 has-info mb-space-m">
+                <div className="card-header flex flex-baseline has-icon">
+                  <i className="dashing-icon dashing-icon--alert-filled" />
+                  <h4 className="text-color--blue no-margin">Please Note</h4>
+                </div>
+                <p className="card-content no-margin">This is an error info card.</p>
+              </div>
+
+              <div className="card error-card-4 has-warning mb-space-m">
+                <div className="card-header flex flex-baseline has-icon">
+                  <i className="dashing-icon dashing-icon--alert-filled" />
+                  <h4 className="text-color--orange no-margin">Warning</h4>
+                </div>
+                <p className="card-content no-margin">This is an error info card.</p>
+              </div>
+
+              <div className="card error-card-4 has-error mb-space-m">
                 <div className="card-header flex flex-baseline has-icon">
                   <i className="dashing-icon dashing-icon--alert-filled dashing-icon--red" />
                   <h4 className="text-color--red no-margin">Important</h4>
@@ -433,7 +459,7 @@ export default class CardsCode extends React.Component {
                 <p className="card-content no-margin">This is an error info card.</p>
               </div>
 
-              <div className="card warning-card-3 mb-space-m">
+              {/* <div className="card warning-card-3 mb-space-m">
                 <div className="card-header flex flex-baseline has-icon">
                   <i className="dashing-icon dashing-icon--alert-filled" />
                   <h4 className="text-color--orange no-margin">Warning</h4>
@@ -447,7 +473,7 @@ export default class CardsCode extends React.Component {
                   <h4 className="text-color--blue no-margin">Information</h4>
                 </div>
                 <p className="card-content no-margin">This is an info card.</p>
-              </div>
+              </div> */}
 
               {/* <div className="card card-info--gray mt-space-m">
                 <div className="card-header">

--- a/src/pages/components/icons/code.js
+++ b/src/pages/components/icons/code.js
@@ -136,7 +136,7 @@ class Icons extends React.Component {
             </h2>
             <div className="example-container">
               <div className="card">
-                <div className="card-header flex flex-center has-icon">
+                <div className="card-header flex has-icon">
                   <i className="dashing-icon dashing-icon--info-filled" />
                   <h3>Card Header with Icon</h3>
                 </div>
@@ -159,7 +159,7 @@ class Icons extends React.Component {
               <CodeToggle>
 {`<!-- Use flex to align the icon. Us has-icon to give the icon proper spacing -->
 <div class="card">
-  <div class="card-header flex flex-center has-icon">
+  <div class="card-header flex has-icon">
     <i class="dashing-icon dashing-icon--info-filled" />
     <h3>Card Header with Icons</h3>
   </div>

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -150,12 +150,59 @@
   &.card-info {
     background-color: #eaf9ff;
     box-shadow: none;
+    &.is-warning {
+      background-color: #eaf9ff;
+    }
+    &.is-error {
+      border-left: 4px solid $color-red;
+      background-color: $color-white;
+      .dashing-icon::before { color: $color-red; }
+    }
   }
   &.card-info--gray,
   &.card-info--grey {
     background-color: $color-gray-2;
     box-shadow: none;
   }
+}
+
+.error-card {
+  border: 2px solid $color-border;
+  border-radius: 5px;
+  border-left: 4px solid $color-red;
+  background-color: $color-white;
+  .dashing-icon::before { color: $color-red; }
+}
+
+.error-card-2 {
+  border: 2px solid $color-red;
+  border-radius: 5px;
+  background-color: $color-white;
+  .dashing-icon::before { color: $color-red; }
+}
+
+.error-card-3 {
+  box-shadow: none;
+  border: 2px solid $color-border;
+  border-left: 5px solid $color-red;
+  background-color: $color-white;
+  .dashing-icon::before { color: $color-red; }
+}
+
+.warning-card-3 {
+  box-shadow: none;
+  border: 2px solid $color-border;
+  border-left: 5px solid $color-orange;
+  background-color: $color-white;
+  .dashing-icon::before { color: $color-orange; }
+}
+
+.info-card-3 {
+  box-shadow: none;
+  border: 2px solid $color-border;
+  border-left: 5px solid $color-blue;
+  background-color: $color-white;
+  .dashing-icon::before { color: $color-blue; }
 }
 
 //Set the margin of Cards when they are within a Grid

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -3,7 +3,7 @@
 
 //TODO remove .card--header, .card--content, .card--footer with major release
 
-.card {
+.card, %card {
   background-color: $color-white;
   border-radius: 5px;
   margin: 1.5rem auto;
@@ -150,126 +150,35 @@
       }
     }
   }
-  //Informational card
-  &.card-info {
-    background-color: #eaf9ff;
-    box-shadow: none;
-    &.is-warning {
-      background-color: #eaf9ff;
-    }
-    &.is-error {
-      border-left: 4px solid $color-red;
-      background-color: $color-white;
-      .dashing-icon::before { color: $color-red; }
-    }
-  }
-  &.card-info--gray,
-  &.card-info--grey {
-    background-color: $color-gray-2;
-    box-shadow: none;
-  }
 }
 
-.error-card {
-  border: 2px solid $color-border;
-  border-radius: 5px;
-  // border-left: 4px solid $color-red;
-  background-color: $color-white;
-  position: relative;
-  .dashing-icon::before { color: $color-red; }
-  &::before {
-    content: "";
-    border-left: 6px solid $color-red;
-    top: -2px;
-    bottom: -2px;
-    left: -2px;
-    position: absolute;
-  }
-}
-
-.error-card-3 {
-  // box-shadow: none;
-  border-left: 6px solid $color-border;
-  background-color: $color-white;
-  position: relative;
+.card-info {
+  @extend %card;
   overflow: hidden;
+  border-left: 6px solid $color-blue;
+  background-color: lighten($color-blue, 55%);
+  .dashing-icon::before { color: $color-blue; }
 
-  .card-header { padding-top: 0.75rem; }
-  .card-content { padding: 0.75rem 1rem; }
-
-  // &::before {
-  //   content: "";
-  //   border-left: 8px solid $color-gray-2;
-  //   top: -2px;
-  //   bottom: -2px;
-  //   left: -2px;
-  //   position: absolute;
-  // }
-
-  &.has-info {
-    background-color: lighten($color-blue, 55%);
-    .dashing-icon::before { color: $color-blue; }
-    // &::before { border-left-color: $color-blue; }
-    border-left-color: $color-blue;
-  }
+  .card-header { padding-top: $space-s; }
+  .card-content { padding: $space-s $space-m; }
 
   &.has-warning {
     .dashing-icon::before { color: $color-orange; }
     background-color: lighten($color-orange, 40%);
-    // &::before { border-left-color: $color-orange; }
     border-left-color: $color-orange;
   }
 
   &.has-error {
     .dashing-icon::before { color: $color-red; }
     background-color: lighten($color-red, 45%);
-    // &::before { border-left-color: $color-red; }
     border-left-color: $color-red;
   }
-}
 
-.error-card-4 {
-  box-shadow: none;
-  border: 2px solid $color-gray-2;
-  background-color: lighten($color-red, 45%);
-  position: relative;
-
-  .card-header { padding-top: 0.75rem; }
-  .card-content { padding: 0.75rem 1rem; }
-
-  &.has-info {
-    border-color: $color-blue;
-    background-color: lighten($color-blue, 55%);
-    .dashing-icon::before { color: $color-blue; }
+  &.has-success{
+    .dashing-icon::before { color: $color-green; }
+    background-color: lighten($color-green, 70%);
+    border-left-color: $color-green;
   }
-
-  &.has-warning {
-    border-color: $color-orange;
-    background-color: lighten($color-orange, 40%);
-    .dashing-icon::before { color: $color-orange; }
-  }
-
-  &.has-error {
-    border-color: $color-red;
-    background-color: lighten($color-red, 45%);
-    .dashing-icon::before { color: $color-red; }
-  }
-}
-
-.warning-card-3 {
-  box-shadow: none;
-  border: 2px solid $color-border;
-  border-left: 5px solid $color-orange;
-  background-color: $color-white;
-  .dashing-icon::before { color: $color-orange; }
-}
-
-.info-card-3 {
-  box-shadow: none;
-  border: 2px solid $color-border;
-  border-left: 5px solid $color-blue;
-  background-color: $color-white;
-  .dashing-icon::before { color: $color-blue; }
 }
 
 //Set the margin of Cards when they are within a Grid

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -32,11 +32,7 @@
     &.has-icon {
       display: flex;
       align-items: baseline;
-      i {
-        position: relative;
-        top: -1px;
-        margin-right: $space-xxs;
-      }
+      i { margin-right: $space-xs; }
     }
     h1, h2, h3, h4 { margin-bottom: 0; } //removes default margin-bottom in card-headers
   }

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -154,27 +154,50 @@
 
 .card-info {
   @extend %card;
+
   overflow: hidden;
   border-left: 6px solid $color-blue;
   background-color: lighten($color-blue, 55%);
   .dashing-icon::before { color: $color-blue; }
 
+  .card-info--title {
+    color: $color-blue;
+    margin: 0;
+  }
+
   .card-header { padding-top: $space-s; }
   .card-content { padding: $space-s $space-m; }
 
+  .card-header,
+  .card-content {
+    &.has-icon {
+      display: flex;
+      align-items: baseline;
+      .dashing-icon { margin-right: $space-xs; }
+    }
+    &.has-button {
+      display: flex;
+      align-items: center;
+      button { white-space: nowrap; }
+    }
+  }
+
   &.has-warning {
+    .card-info--title { color: $color-orange; }
     .dashing-icon::before { color: $color-orange; }
     background-color: lighten($color-orange, 40%);
     border-left-color: $color-orange;
   }
 
   &.has-error {
+    .card-info--title { color: $color-red; }
     .dashing-icon::before { color: $color-red; }
     background-color: lighten($color-red, 45%);
     border-left-color: $color-red;
   }
 
-  &.has-success{
+  &.has-success {
+    .card-info--title { color: $color-green; }
     .dashing-icon::before { color: $color-green; }
     background-color: lighten($color-green, 70%);
     border-left-color: $color-green;

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -31,8 +31,12 @@
     }
     &.has-icon {
       display: flex;
-      align-items: center;
-      i { margin-right: $space-xxs; }
+      align-items: baseline;
+      i {
+        position: relative;
+        top: -1px;
+        margin-right: $space-xxs;
+      }
     }
     h1, h2, h3, h4 { margin-bottom: 0; } //removes default margin-bottom in card-headers
   }
@@ -169,24 +173,87 @@
 .error-card {
   border: 2px solid $color-border;
   border-radius: 5px;
-  border-left: 4px solid $color-red;
+  // border-left: 4px solid $color-red;
   background-color: $color-white;
+  position: relative;
   .dashing-icon::before { color: $color-red; }
-}
-
-.error-card-2 {
-  border: 2px solid $color-red;
-  border-radius: 5px;
-  background-color: $color-white;
-  .dashing-icon::before { color: $color-red; }
+  &::before {
+    content: "";
+    border-left: 6px solid $color-red;
+    top: -2px;
+    bottom: -2px;
+    left: -2px;
+    position: absolute;
+  }
 }
 
 .error-card-3 {
-  box-shadow: none;
-  border: 2px solid $color-border;
-  border-left: 5px solid $color-red;
+  // box-shadow: none;
+  border-left: 6px solid $color-border;
   background-color: $color-white;
-  .dashing-icon::before { color: $color-red; }
+  position: relative;
+  overflow: hidden;
+
+  .card-header { padding-top: 0.75rem; }
+  .card-content { padding: 0.75rem 1rem; }
+
+  // &::before {
+  //   content: "";
+  //   border-left: 8px solid $color-gray-2;
+  //   top: -2px;
+  //   bottom: -2px;
+  //   left: -2px;
+  //   position: absolute;
+  // }
+
+  &.has-info {
+    background-color: lighten($color-blue, 55%);
+    .dashing-icon::before { color: $color-blue; }
+    // &::before { border-left-color: $color-blue; }
+    border-left-color: $color-blue;
+  }
+
+  &.has-warning {
+    .dashing-icon::before { color: $color-orange; }
+    background-color: lighten($color-orange, 40%);
+    // &::before { border-left-color: $color-orange; }
+    border-left-color: $color-orange;
+  }
+
+  &.has-error {
+    .dashing-icon::before { color: $color-red; }
+    background-color: lighten($color-red, 45%);
+    // &::before { border-left-color: $color-red; }
+    border-left-color: $color-red;
+  }
+}
+
+.error-card-4 {
+  box-shadow: none;
+  border: 2px solid $color-gray-2;
+  background-color: lighten($color-red, 45%);
+  position: relative;
+
+  .card-header { padding-top: 0.75rem; }
+  .card-content { padding: 0.75rem 1rem; }
+
+  &.has-info {
+    border-color: $color-blue;
+    background-color: lighten($color-blue, 55%);
+    .dashing-icon::before { color: $color-blue; }
+  }
+
+  &.has-warning {
+    border-color: $color-orange;
+    background-color: lighten($color-orange, 40%);
+    .dashing-icon::before { color: $color-orange; }
+  }
+
+  &.has-error {
+    border-color: $color-red;
+    background-color: lighten($color-red, 45%);
+    .dashing-icon::before { color: $color-red; }
+  }
 }
 
 .warning-card-3 {

--- a/src/sass/modules/icons/icons.scss
+++ b/src/sass/modules/icons/icons.scss
@@ -139,5 +139,6 @@
 }
 
 .flex.has-icon {
+  align-items: baseline;
   .dashing-icon { margin-right: $space-xs; }
 }


### PR DESCRIPTION
Removed `card-banner` and replaced with `card-info`. Using `card-info` as a banner and info card now.

Default state of the `card-info` is blue. Adding `.has-error`, `.has-success` or `.has-warning` will give it the appropriate styles.

Update the guidelines page for banners to reflect the new styles.

---

![image](https://user-images.githubusercontent.com/26393016/71372579-6c36f400-257a-11ea-9441-c19889276b9f.png)

![image](https://user-images.githubusercontent.com/26393016/71372713-c041d880-257a-11ea-8b7a-957e1d13692e.png)

