### PR TITLE
Paragon Bug Fixes

### DIFF
--- a/src/pages/components/cards/guidelines.js
+++ b/src/pages/components/cards/guidelines.js
@@ -20,7 +20,7 @@ export default () => (
           <p className="intro">Cards are used to visually group certain topics of information. This makes it easier for users to quickly find and compare information of interest. Avoid using to much content within a card to overload the user.</p>
 
           <h2 className="has-number has-number--one no-margin--top">Buttons within Cards</h2>
-            <p>Call to actions within cards should be placed in the card footer and left aligned. If there is only one action in the footer, this should be center aligned. This pattern supports the <Link to="https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/">F-pattern layout</Link>.</p>
+            <p>Call to actions within cards should be placed in the card footer and left aligned. If there is only one action in the footer, this should be center aligned. This pattern supports the <a href="https://www.nngroup.com/articles/f-shaped-pattern-reading-web-content/" target="_blank">F-pattern layout</a>.</p>
             <div className="image-container double-padding">
               <div className="card card--example-footer">
                 <div className="card--footer" style={{ paddingTop: "1rem" }}>

--- a/src/pages/components/icons/code.js
+++ b/src/pages/components/icons/code.js
@@ -136,7 +136,7 @@ class Icons extends React.Component {
             </h2>
             <div className="example-container">
               <div className="card">
-                <div className="card-header flex flex-center has-icon">
+                <div className="card-header has-icon">
                   <i className="dashing-icon dashing-icon--info-filled" />
                   <h3>Card Header with Icon</h3>
                 </div>
@@ -159,7 +159,7 @@ class Icons extends React.Component {
               <CodeToggle>
 {`<!-- Use flex to align the icon. Us has-icon to give the icon proper spacing -->
 <div class="card">
-  <div class="card-header flex flex-center has-icon">
+  <div class="card-header has-icon">
     <i class="dashing-icon dashing-icon--info-filled" />
     <h3>Card Header with Icons</h3>
   </div>

--- a/src/pages/components/icons/code.js
+++ b/src/pages/components/icons/code.js
@@ -97,8 +97,8 @@ class Icons extends React.Component {
             <div className={`icon-code--container ${this.state.activeId === null ? "" : "slideIn" }`}>
               <div className="icon-code">
                 <h3 className="text-color--white no-margin">{this.state.iconText}</h3>
-                <div className="hover-code" onClick={() => this.copyToClipboard('code')}>
-                  <code className="language-html show" style={{ display: "inline-block" }}>
+                <div className="hover-code" onClick={() => this.copyToClipboard('code.text-to-copy')}>
+                  <code className="text-to-copy language-html show" style={{ display: "inline-block" }}>
                     {`<i class="dashing-icon dashing-icon--${this.state.iconText}"></i>`}
                   </code>
                   <button type="button" className={`button--secondary button--copy-code ${this.state.copyCodeClass}`}>{this.state.copyCodeText}</button>

--- a/src/pages/style/spacing/code.js
+++ b/src/pages/style/spacing/code.js
@@ -97,7 +97,8 @@ $space-xxl: 3rem;`}
 
 
           <h2 className="mt-space-xl">Individual Spacing</h2>
-          <p>Add <code className="example-text">_mobile</code> to the end of an individual spacing class to apply only on mobile.</p>
+          <p className="no-margin--bottom">Add the screen breakpoint to the end of an individual spacing class to apply only on that breakpoint.</p>
+          <p>For example: Adding margin to just mobile devices. <code className="example-text">m-space-m_mobile</code></p>
 
           <div className="example-container">
 
@@ -164,8 +165,11 @@ $space-xxl: 3rem;`}
 <div class="ml-space-xs"></div> <!-- margin-left: 0.5rem; -->
 <div class="p-space-m"></div> <!-- padding: 1rem; -->
 
-<!-- Mobile only spacing -->
+<!-- Breakpoint specific spacing -->
 <div class="p-space-m_mobile"></div> <!-- padding: 1rem; -->
+<div class="p-space-m_tablet-and-below"></div> <!-- padding: 1rem; -->
+<div class="p-space-m_tablet"></div> <!-- padding: 1rem; -->
+<div class="p-space-m_desktop"></div> <!-- padding: 1rem; -->
 `}
             </CodeToggle>
             </div>

--- a/src/pages/style/spacing/code.js
+++ b/src/pages/style/spacing/code.js
@@ -97,6 +97,7 @@ $space-xxl: 3rem;`}
 
 
           <h2 className="mt-space-xl">Individual Spacing</h2>
+          <p>Add <code className="example-text">_mobile</code> to the end of an individual spacing class to apply only on mobile.</p>
 
           <div className="example-container">
 
@@ -162,6 +163,9 @@ $space-xxl: 3rem;`}
 {`<div class="mt-space-xl"></div> <!-- margin-top: 2rem; -->
 <div class="ml-space-xs"></div> <!-- margin-left: 0.5rem; -->
 <div class="p-space-m"></div> <!-- padding: 1rem; -->
+
+<!-- Mobile only spacing -->
+<div class="p-space-m_mobile"></div> <!-- padding: 1rem; -->
 `}
             </CodeToggle>
             </div>

--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -140,6 +140,9 @@ $sides: (
 
 .flex-column  { flex-direction: column; }
 .flex-wrap    { flex-wrap: wrap; }
+.flex-wrap_mobile {
+  @media #{$phone} { flex-wrap: wrap; }
+}
 
 .flex-center   { align-items: center; }
 .flex-baseline { align-items: baseline; }
@@ -156,3 +159,13 @@ $sides: (
 }
 .flex-grow { flex: 1 0 auto; }
 .flex-none { flex: none; }
+//Distribute children items in flex container evenly
+.flex-distribute > * { flex: 1 1 0px; }
+
+
+//Make item full width on mobile
+.flex-full_mobile {
+  @media #{$phone} {
+    flex: 1 100% !important;
+  }
+}

--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -162,24 +162,22 @@ $sides: (
 
 .flex { display: flex; }
 
-.flex-column  { display: flex; flex-direction: column; }
-.flex-wrap    { display: flex; flex-wrap: wrap; }
+.flex-column  { flex-direction: column; }
+.flex-wrap    { flex-wrap: wrap; }
 .flex-wrap {
   &_mobile { @media #{$phone} { flex-wrap: wrap; } }
   &_tablet-and-below { @media #{$tablet-and-below} { flex-wrap: wrap; } }
   &_tablet { @media #{$tablet} { flex-wrap: wrap; } }
 }
 
-.flex-vcenter,
-.flex-vc       { display: flex; align-items: center; }
-.flex-center,
-.flex-centered { display: flex; align-items: center; justify-content: center; }
-.flex-baseline { display: flex; align-items: baseline; }
-.flex-stretch  { display: flex; align-items: stretch; }
-.flex-start    { display: flex; align-items: flex-start; }
-.flex-end      { display: flex; align-items: flex-end; }
+.flex-vcenter  { align-items: center; }
+.flex-center   { align-items: center; justify-content: center; }
+.flex-baseline { align-items: baseline; }
+.flex-stretch  { align-items: stretch; }
+.flex-start    { align-items: flex-start; }
+.flex-end      { align-items: flex-end; }
 
-.flex-justify  { display: flex; justify-content: space-between; }
+.flex-justify  { justify-content: space-between; }
 
 .flex-auto {
   flex: 1 1 auto;

--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -19,6 +19,7 @@ $widths: (
   $max-width: if($width == '', '', #{$width-var});
   .content#{$width} { //.content-s
     max-width: #{$max-width} !important; //max-width: 600px;
+		@media #{$phone} { max-width: 100% !important; }
   }
 }
 

--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -64,26 +64,32 @@ $sides: (
     .m#{$prefix}-#{$space} { //.mb-space-xs
       margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;
       &_mobile {
-        @media #{$phone} { margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;}
+        @media #{$phone} { margin#{$property}: #{$space-var} !important; /* margin-bottom: space-xs; */ }
       }
       &_tablet-and-below {
-        @media #{$tablet-and-below} { margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;}
+        @media #{$tablet-and-below} { margin#{$property}: #{$space-var} !important; /* margin-bottom: space-xs; */ }
       }
       &_tablet {
-        @media #{$tablet} { margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;}
+        @media #{$tablet} { margin#{$property}: #{$space-var} !important; /* margin-bottom: space-xs; */ }
+      }
+      &_desktop {
+        @media #{$desktop} { margin#{$property}: #{$space-var} !important; /* margin-bottom: space-xs; */ }
       }
     }
 
     .p#{$prefix}-#{$space} { //.p-space-m
       padding#{$property}: #{$space-var} !important; //padding: space-m;
       &_mobile {
-        @media #{$phone} { padding#{$property}: #{$space-var} !important; //padding: space-m;}
+        @media #{$phone} { padding#{$property}: #{$space-var} !important; /* padding: space-m; */ }
       }
       &_tablet-and-below {
-        @media #{$tablet-and-below} { padding#{$property}: #{$space-var} !important; //padding: space-m;}
+        @media #{$tablet-and-below} { padding#{$property}: #{$space-var} !important; /* padding: space-m; */ }
       }
       &_tablet {
-        @media #{$tablet} { padding#{$property}: #{$space-var} !important; //padding: space-m;}
+        @media #{$tablet} { padding#{$property}: #{$space-var} !important; /* padding: space-m; */ }
+      }
+      &_desktop {
+        @media #{$desktop} { padding#{$property}: #{$space-var} !important; /* padding: space-m; */ }
       }
     }
   }
@@ -165,9 +171,9 @@ $sides: (
 }
 
 .flex-vcenter,
-.flex-vc       { display: flex; align-items: center;}
+.flex-vc       { display: flex; align-items: center; }
 .flex-center,
-.flex-centered { display: flex; align-items: center; justify-content: center;  }
+.flex-centered { display: flex; align-items: center; justify-content: center; }
 .flex-baseline { display: flex; align-items: baseline; }
 .flex-stretch  { display: flex; align-items: stretch; }
 .flex-start    { display: flex; align-items: flex-start; }

--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -148,19 +148,24 @@ $sides: (
 
 .flex { display: flex; }
 
-.flex-column  { flex-direction: column; }
-.flex-wrap    { flex-wrap: wrap; }
-.flex-wrap_mobile {
-  @media #{$phone} { flex-wrap: wrap; }
+.flex-column  { display: flex; flex-direction: column; }
+.flex-wrap    { display: flex; flex-wrap: wrap; }
+.flex-wrap {
+  &_mobile { @media #{$phone} { flex-wrap: wrap; } }
+  &_tablet-and-below { @media #{$tablet-and-below} { flex-wrap: wrap; } }
+  &_tablet { @media #{$tablet} { flex-wrap: wrap; } }
 }
 
-.flex-center   { align-items: center; }
-.flex-baseline { align-items: baseline; }
-.flex-stretch  { align-items: stretch; }
-.flex-start    { align-items: flex-start; }
-.flex-end      { align-items: flex-end; }
+.flex-vcenter,
+.flex-vc       { display: flex; align-items: center;}
+.flex-center,
+.flex-centered { display: flex; align-items: center; justify-content: center;  }
+.flex-baseline { display: flex; align-items: baseline; }
+.flex-stretch  { display: flex; align-items: stretch; }
+.flex-start    { display: flex; align-items: flex-start; }
+.flex-end      { display: flex; align-items: flex-end; }
 
-.flex-justify  { justify-content: space-between; }
+.flex-justify  { display: flex; justify-content: space-between; }
 
 .flex-auto {
   flex: 1 1 auto;
@@ -173,9 +178,9 @@ $sides: (
 .flex-distribute > * { flex: 1 1 0px; }
 
 
-//Make item full width on mobile
-.flex-full_mobile {
-  @media #{$phone} {
-    flex: 1 100% !important;
-  }
+//Make item full width
+.flex-full {
+  &_mobile { @media #{$phone} { flex: 1 100% !important; } }
+  &_tablet-and-below { @media #{$tablet-and-below} { flex: 1 100% !important; } }
+  &_tablet { @media #{$tablet} { flex: 1 100% !important; } }
 }

--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -64,9 +64,19 @@ $sides: (
     .m#{$prefix}-#{$space} { //.mb-space-xs
       margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;
     }
+    .m#{$prefix}-#{$space}_mobile { //.mb-space-xs_mobile
+      @media #{$phone} {
+        margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;
+      }
+    }
 
     .p#{$prefix}-#{$space} { //.p-space-m
       padding#{$property}: #{$space-var} !important; //padding: space-m;
+    }
+    .p#{$prefix}-#{$space}_mobile { //.pb-space-xs_mobile
+      @media #{$phone} {
+        padding#{$property}: #{$space-var} !important; //padding: space-m;
+      }
     }
   }
 }

--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -63,19 +63,27 @@ $sides: (
     $property: if($prefix == '', '', -#{$value});
     .m#{$prefix}-#{$space} { //.mb-space-xs
       margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;
-    }
-    .m#{$prefix}-#{$space}_mobile { //.mb-space-xs_mobile
-      @media #{$phone} {
-        margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;
+      &_mobile {
+        @media #{$phone} { margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;}
+      }
+      &_tablet-and-below {
+        @media #{$tablet-and-below} { margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;}
+      }
+      &_tablet {
+        @media #{$tablet} { margin#{$property}: #{$space-var} !important; //margin-bottom: space-xs;}
       }
     }
 
     .p#{$prefix}-#{$space} { //.p-space-m
       padding#{$property}: #{$space-var} !important; //padding: space-m;
-    }
-    .p#{$prefix}-#{$space}_mobile { //.pb-space-xs_mobile
-      @media #{$phone} {
-        padding#{$property}: #{$space-var} !important; //padding: space-m;
+      &_mobile {
+        @media #{$phone} { padding#{$property}: #{$space-var} !important; //padding: space-m;}
+      }
+      &_tablet-and-below {
+        @media #{$tablet-and-below} { padding#{$property}: #{$space-var} !important; //padding: space-m;}
+      }
+      &_tablet {
+        @media #{$tablet} { padding#{$property}: #{$space-var} !important; //padding: space-m;}
       }
     }
   }

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -31,8 +31,12 @@
     }
     &.has-icon {
       display: flex;
-      align-items: center;
-      i { margin-right: $space-xxs; }
+      align-items: baseline;
+      i {
+        margin-right: $space-xs;
+        position: relative;
+        top: -1px;
+      }
     }
     h1, h2, h3, h4 { margin-bottom: 0; } //removes default margin-bottom in card-headers
   }

--- a/src/sass/modules/typography/_typography.scss
+++ b/src/sass/modules/typography/_typography.scss
@@ -81,8 +81,12 @@ a {
 
   &.no-decoration {
     text-decoration: none;
-    color: $color-text;
-    font-weight: $font-weight-normal;
+    color: inherit;
+    font-weight: inherit;
+    
+    &:hover, &:focus {
+      opacity: 1;
+    }
   }
 }
 


### PR DESCRIPTION
**Fixes the below issues:**
#113 : Make phone content 100% width
#106 : Fix link
#84 : Remove opacity change when using `.no-decoration`. Inherit colors instead of declaring them.
#88 : Updated code on icons page
#107 : Make the element the copy code it looking at more specific so it doesn't grab every `code` element on the page

---

Added new flex utilities.

Updated the margin/padding utility to have the ability to just apply on mobile.