### PR TITLE
Allow zero length units for IE. Update flex shorthand to add units.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,6 +3,7 @@
   "rules": {
     "indentation": "tab",
     "unit-no-unknown": true,
+    "length-zero-no-unit": null,
     # Rules to fix #
     "scss/at-extend-no-missing-placeholder": null,
     "max-nesting-depth": 7, # This should be 3

--- a/src/sass/base/utilities/_utilities.scss
+++ b/src/sass/base/utilities/_utilities.scss
@@ -247,7 +247,7 @@ $display: (
 .flex-grow { flex: 1 0 auto; }
 .flex-none { flex: none; }
 //Distribute children items in flex container evenly
-.flex-distribute > * { flex: 1 1 0; }
+.flex-distribute > * { flex: 1 1 0px; }
 
 
 //Make item full width

--- a/src/sass/modules/forms/forms.scss
+++ b/src/sass/modules/forms/forms.scss
@@ -268,7 +268,7 @@ fieldset {
 
 		@media #{$tablet} {
 			-ms-flex: 1 1 auto;
-			flex: 1 1 0;
+			flex: 1 1 0px;
 			margin-left: 1rem;
 			margin-right: 0;
 			min-width: 180px;

--- a/src/sass/modules/table/table.scss
+++ b/src/sass/modules/table/table.scss
@@ -36,7 +36,7 @@ $flex-table--header-text: $color-white;
 
 		li {
 			@extend .no-wrap;
-			flex: 1 1 0;
+			flex: 1 1 0px;
 			padding-right: 0.5rem;
 			@media #{$phone} {
 				white-space: normal;


### PR DESCRIPTION
Fixed #128 

---

IE likes to have the units on Flex box shorthand. IF not, things start to look funky. Stylelint has a rule to remove these, so I disabled that rule.