### PR TITLE
Add min-width to info cards

### DIFF
--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -145,8 +145,7 @@
 
 			th {
 				background-color: $color-background;
-				border-color: $color-border;
-				border-top: 2px solid;
+				border-top: 2px solid $color-border;
 				padding: $space-xs $space-m !important;
 			}
 
@@ -179,7 +178,7 @@
 	border-left: 6px solid $color-blue;
 	min-width: 100%;
 	overflow: hidden;
-	
+
 	.dashing-icon::before { color: $color-blue; }
 
 	.card-info--title {

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -177,8 +177,9 @@
 	@extend %card;
 	background-color: lighten($color-blue, 55%);
 	border-left: 6px solid $color-blue;
-
+	min-width: 100%;
 	overflow: hidden;
+	
 	.dashing-icon::before { color: $color-blue; }
 
 	.card-info--title {


### PR DESCRIPTION
Fixed #115 

---

If the banner did not have enough content, it would only be as wide as the content. Added a `min-width` to the item.

**Bonus:**
- Card Table had a black border on the top. Updated to our border color.