### PR TITLE
Add loading Table examples / code

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "pre-commit": "stylelint",
   "dependencies": {
     "@tippy.js/react": "^2.1.1",
+    "classnames": "^2.2.6",
     "gatsby": "^2.19.45",
     "gatsby-plugin-google-fonts": "0.0.4",
     "gatsby-plugin-manifest": "^2.0.20",

--- a/src/pages/components/tables/code.js
+++ b/src/pages/components/tables/code.js
@@ -470,8 +470,7 @@ $table--border: $gray-200 !default;`}
           </div>
         </div>
         <CodeToggle>
-{`<!-- Use row-expandable to give space for the dashing-icon -->
-<div className="flex-table is-condensed is-loading">
+{`<div className="flex-table is-loading">
 <ol className="table-row--header">
   <li>Column 1</li>
   <li>Column 2</li>

--- a/src/pages/components/tables/code.js
+++ b/src/pages/components/tables/code.js
@@ -442,7 +442,7 @@ $table--border: $gray-200 !default;`}
         </h2>
         <div className="example-container">
 
-          <div className="flex-table row-expandable is-loading">
+          <div className="flex-table is-loading">
             <ol className="table-row--header">
               <li>Column 1</li>
               <li>Column 2</li>

--- a/src/pages/components/tables/code.js
+++ b/src/pages/components/tables/code.js
@@ -436,6 +436,68 @@ $table--border: $gray-200 !default;`}
 </div>`}
           </CodeToggle>
         </div>
+
+        <h2 className="mt-space-xl" id="flex-table">Flex Table - Loading
+          <Link to={location.pathname + "/#flex-table-loading"} className="button button--transparent button--copy-link"></Link>
+        </h2>
+        <div className="example-container">
+
+          <div className="flex-table row-expandable is-loading">
+            <ol className="table-row--header">
+              <li>Column 1</li>
+              <li>Column 2</li>
+              <li>Column 3</li>
+              <li>Column 4</li>
+            </ol>
+            <ol className="table-row">
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+            </ol>
+            <ol className="table-row">
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+            </ol>
+            <ol className="table-row">
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+              <li>&nbsp;</li>
+            </ol>
+          </div>
+        </div>
+        <CodeToggle>
+{`<!-- Use row-expandable to give space for the dashing-icon -->
+<div className="flex-table is-condensed is-loading">
+<ol className="table-row--header">
+  <li>Column 1</li>
+  <li>Column 2</li>
+  <li>Column 3</li>
+  <li>Column 4</li>
+</ol>
+<ol className="table-row">
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+</ol>
+<ol className="table-row">
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+</ol>
+<ol className="table-row">
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+  <li>&nbsp;</li>
+</ol>
+</div>`}
+        </CodeToggle>
       </div>
             {/* <div className="column column--full">
               <h2 className="example-header no-margin--top" id="defaultTable">Default Table

--- a/src/pages/components/tables/loadingTable.js
+++ b/src/pages/components/tables/loadingTable.js
@@ -1,0 +1,87 @@
+import cn from "classnames";
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class LoadingTable extends React.Component {
+
+  render() {
+    const LoadingTable = this.LoadingTable.bind(this);
+
+    return (
+      <LoadingTable />
+    );
+  }
+
+  LoadingTable() {
+    const TableTitle = this.TableTitle.bind(this);
+    const TableRows = this.TableRows.bind(this);
+    const { children, isExpandable, isSelectable } = this.props;
+
+    return (
+      <div className={cn({
+          "row-expandable": isExpandable,
+          "row-selectable": isSelectable,
+          "flex-table is-loading": true
+        })}>
+        <TableTitle />
+        <ol className="table-row--header">
+          {children}
+        </ol>
+        <TableRows />
+      </div>
+    );
+  }
+
+  TableTitle() {
+    const { tableTitle } = this.props;
+
+    if (tableTitle != null) {
+      return (
+        <h3 className="flex-table--title">{tableTitle}</h3>
+      );
+    } else {
+      return (null);
+    }
+  }
+
+  TableRows() {
+    const { numberOfColumns } = this.props;
+    const { numberOfRows } = this.props;
+
+    return (
+      <>
+      {
+        Array.from({ length: numberOfRows }, (_, r) => (
+          <ol className="table-row" key={r}>
+            {
+              Array.from({ length: numberOfColumns }, (_, c) => (
+                <li key={c}>&nbsp;</li>
+              ))
+            }
+          </ol>
+        ))
+      }
+      </>
+    );
+  }
+}
+
+LoadingTable.defaultProps = {
+  hasTitle: false,
+  hasFooter: false,
+  isExpandable: false,
+  isSelectable: false,
+  numberOfColumns: 4,
+  numberOfRows: 3,
+  tableTitle: null
+};
+
+LoadingTable.propTypes = {
+  hasTitle: PropTypes.bool,
+  hasFooter: PropTypes.bool,
+  isExpandable: PropTypes.bool,
+  isSelectable: PropTypes.bool,
+  numberOfColumns: PropTypes.number,
+  numberOfRows: PropTypes.number,
+  tableTitle: PropTypes.string
+};

--- a/src/pages/components/tables/loadingTable.js
+++ b/src/pages/components/tables/loadingTable.js
@@ -67,8 +67,6 @@ export default class LoadingTable extends React.Component {
 }
 
 LoadingTable.defaultProps = {
-  hasTitle: false,
-  hasFooter: false,
   isExpandable: false,
   isSelectable: false,
   numberOfColumns: 4,
@@ -77,8 +75,6 @@ LoadingTable.defaultProps = {
 };
 
 LoadingTable.propTypes = {
-  hasTitle: PropTypes.bool,
-  hasFooter: PropTypes.bool,
   isExpandable: PropTypes.bool,
   isSelectable: PropTypes.bool,
   numberOfColumns: PropTypes.number,

--- a/src/sass/base/extendables/_extendables.scss
+++ b/src/sass/base/extendables/_extendables.scss
@@ -72,3 +72,27 @@
 		min-height: 2rem;
 	}
 }
+
+/* Loading animation
+  =========================================================================== */
+%loading-animation {
+	* {
+		background-color: $color-background;
+		border-radius: 3px;
+		height: 1.25rem;
+		overflow: hidden;
+		position: relative;
+
+		&::after {
+			animation: loadingCard 1.2s infinite;
+			background: linear-gradient(90deg, transparent, rgba($color-black, 0.07), transparent);
+			content: '';
+			display: block;
+			height: 100%;
+			position: absolute;
+			top: 0;
+			transform: translateX(-100%);
+			width: 100%;
+		}
+	}
+}

--- a/src/sass/modules/card/_card.scss
+++ b/src/sass/modules/card/_card.scss
@@ -251,27 +251,8 @@
 	.card--content,
 	.card-footer,
 	.card--footer {
+		@extend %loading-animation;
 		overflow: hidden;
-
-		* { //Targets all elements inside the card header, content, and footer
-			background-color: $color-background;
-			border-radius: 3px;
-			height: 1.25rem;
-			overflow: hidden;
-			position: relative;
-
-			&::after {
-				animation: loadingCard 1.2s infinite;
-				background: linear-gradient(90deg, transparent, rgba($color-black, 0.07), transparent);
-				content: '';
-				display: block;
-				height: 100%;
-				position: absolute;
-				top: 0;
-				transform: translateX(-100%);
-				width: 100%;
-			}
-		}
 	}
 
 	.card-header,

--- a/src/sass/modules/table/table.scss
+++ b/src/sass/modules/table/table.scss
@@ -214,6 +214,29 @@ $flex-table--header-text: $color-white;
 	}
 }
 
+/* Flex Table Loading Animation
+  =========================================================================== */
+.flex-table.is-loading {
+	overflow: hidden;
+
+	.table-row {
+		@extend %loading-animation;
+		overflow: hidden;
+
+		li { margin-right: 2rem; }
+	}
+
+	// Fixes li spacing for icon for expandable loading table
+	&.row-expandable {
+		.table-row li:first-of-type {
+			left: inherit;
+			padding-right: inherit;
+			position: inherit;
+		}
+	}
+
+}
+
 
 /* Default Table Styles
   =========================================================================== */

--- a/src/sass/modules/table/table.scss
+++ b/src/sass/modules/table/table.scss
@@ -234,13 +234,13 @@ $flex-table--header-text: $color-white;
 			right: 0;
 
 			&:not(:last-child) {
-				margin-bottom: 0.5rem;
+				margin-bottom: $space-xs;
 				@media #{$tablet} {
 					margin-bottom: 0;
 				}
 			}
 			@media #{$tablet} {
-				margin-right: 2rem;
+				margin-right: $space-xl;
 			}
 		}
 	}

--- a/src/sass/modules/table/table.scss
+++ b/src/sass/modules/table/table.scss
@@ -223,15 +223,36 @@ $flex-table--header-text: $color-white;
 		@extend %loading-animation;
 		overflow: hidden;
 
-		li { margin-right: 2rem; }
+		&:hover {
+			background-color: inherit;
+			cursor: default;
+		}
+
+		li {
+			margin-top: 0;
+			padding-right: 0 !important;
+			right: 0;
+
+			&:not(:last-child) {
+				margin-bottom: 0.5rem;
+				@media #{$tablet} {
+					margin-bottom: 0;
+				}
+			}
+			@media #{$tablet} {
+				margin-right: 2rem;
+			}
+		}
 	}
 
 	// Fixes li spacing for icon for expandable loading table
 	&.row-expandable {
 		.table-row li:first-of-type {
 			left: inherit;
+			margin-top: 0;
 			padding-right: inherit;
 			position: inherit;
+			right: 0;
 		}
 	}
 


### PR DESCRIPTION
#127 

---

Took the loading card concept and applied it to Loading tables. Tried to keep the table headers, but show the loading bar instead of content.

- Added all the appropriate CSS
- Added a React component for the LoadingTable that can be copied over to the appropriate React apps for smoother implementation (Paragon examples are in HTML only though)

**Examples:**
---
<img width="601" alt="Screen Shot 2020-06-19 at 1 42 48 PM" src="https://user-images.githubusercontent.com/26393016/85176213-e650e880-b23e-11ea-999a-bc161ff65d8a.png">
<img width="602" alt="Screen Shot 2020-06-19 at 1 43 19 PM" src="https://user-images.githubusercontent.com/26393016/85176214-e6e97f00-b23e-11ea-94e5-4343c537ff30.png">
<img width="601" alt="Screen Shot 2020-06-19 at 1 44 22 PM" src="https://user-images.githubusercontent.com/26393016/85176215-e6e97f00-b23e-11ea-9b7b-e45dc384441d.png">
