### PR TITLE
Adjust flex on progress labels

### DIFF
--- a/src/sass/modules/progress-stepper/progress-stepper.scss
+++ b/src/sass/modules/progress-stepper/progress-stepper.scss
@@ -29,7 +29,7 @@ $progress-color: $color-green !default; //Override this variable to change the c
 .progress-label a {
 	color: $color-subtext;
 	display: flex;
-	flex-grow: 1;
+	flex: 1 1 0;
 	font-size: 0.8rem;
 	font-weight: $font-weight-semibold;
 	justify-content: center;


### PR DESCRIPTION
With Progress step labels that are different length, setting the flex-basis to 0 was needed to make them all the same length.

### Before:
<img width="747" alt="Screen Shot 2020-09-04 at 9 58 49 AM" src="https://user-images.githubusercontent.com/26393016/92253945-c8863d80-ee95-11ea-8738-4bb1097f53ad.png">


### After:
<img width="749" alt="Screen Shot 2020-09-04 at 9 59 05 AM" src="https://user-images.githubusercontent.com/26393016/92253815-996fcc00-ee95-11ea-9584-a0011bf7d4bd.png">