### PR TITLE
Make default tag not-selectable

### DIFF
--- a/src/pages/components/tags/code.js
+++ b/src/pages/components/tags/code.js
@@ -89,18 +89,19 @@ class TagsCode extends React.Component {
 </div>`}
               </CodeToggle>
 
-              <h2 className="example-header" id="tagNoLink">Tag No Link
+              <h2 className="example-header" id="tagNoLink">Selectable Tag
                 <Link to={location.pathname + "/#tagNoLink"} className="button button--transparent button--copy-link"></Link>
               </h2>
+              <p>To make a tag clickable, apply the class <code className="example-text">.is-selectable</code> to the <code className="example-text">.tag</code>.</p>
         			<div className="row example-container">
             			<div className="column column--full ">
-            				<div className="tag tag--blue tag--no-link tag--solid" href=" ">Blue Tag</div>
-        					<div className="tag tag--gray tag--no-link tag--solid" href=" ">Gray Tag</div>
+            				<a className="tag tag--blue is-selectable tag--solid" href=" ">Blue Tag</a>
+        					<a className="tag tag--gray is-selectable tag--solid" href=" ">Gray Tag</a>
             			</div>
             		</div>
                 <CodeToggle>
-{`<a class="tag tag--blue tag--no-link tag--solid">Blue Tag</a>
-<a class="tag tag--gray tag--no-link tag--solid">Gray Tag</a>`}
+{`<a class="tag tag--blue is-selectable tag--solid">Blue Tag</a>
+<a class="tag tag--gray is-selectable tag--solid">Gray Tag</a>`}
                 </CodeToggle>
 
                 <h2 className="example-header" id="tagColors">Tag Colors

--- a/src/sass/base/mixins/_mixins.scss
+++ b/src/sass/base/mixins/_mixins.scss
@@ -120,8 +120,8 @@
 	border-color: $tag-color;
 	color: $color;
 
-	&:not(.tag--no-link):hover,
-	&:not(.tag--no-link):focus {
+	&.is-selectable:hover,
+	&.is-selectable:focus {
 		border-color: darken($tag-color, 20%);
 		color: lighten($color, 10%);
 	}
@@ -133,8 +133,8 @@
 	border-color: $color-gray-3;
 	color: $color;
 
-	&:not(.tag--no-link):hover,
-	&:not(.tag--no-link):focus {
+	&.is-selectable:hover,
+	&.is-selectable:focus {
 		border-color: $color;
 		color: lighten($color, 10%);
 	}

--- a/src/sass/modules/tags/tags.scss
+++ b/src/sass/modules/tags/tags.scss
@@ -2,7 +2,7 @@
   =========================================================================== */
 
 $tags: '.tag';
-$tag-hover-rules: '&:not(.tag--no-link):hover .tag, &:not(.tag--no-link):focus .tag';
+$tag-hover-rules: '.is-selectable';
 $tag-default-color: $color-gray-2;
 
 /* Tag Extendables
@@ -14,23 +14,21 @@ $tag-default-color: $color-gray-2;
 	border: 2px solid $tag-default-color;
 	border-radius: 3px;
 	color: $color-blue;
-	cursor: pointer;
 	display: inline-block;
 	font-size: $font-size-xsmall;
 	font-weight: $font-weight-semibold;
 	margin: 0.25rem;
 	min-width: 1rem;
 	padding: 0.1rem 0.25rem;
+	pointer-events: none;
 	text-decoration: none;
 	text-transform: capitalize;
 
-	&:not(.tag--no-link):hover,
-	&:not(.tag--no-link):focus {
-		border: 2px solid $color-blue;
-		color: $color-blue;
+	&:hover,
+	&:focus {
+		cursor: default;
 		opacity: 1;
 		text-decoration: none;
-		transition: border-color 0.1s ease-in-out;
 	}
 }
 
@@ -39,6 +37,20 @@ $tag-default-color: $color-gray-2;
 
 #{$tags} {
 	@extend %tag;
+
+	&.is-selectable {
+		cursor: pointer;
+		pointer-events: auto;
+
+		&:hover,
+		&:focus {
+			border: 2px solid $color-blue;
+			color: $color-blue;
+			opacity: 1;
+			text-decoration: none;
+			transition: border-color 0.1s ease-in-out;
+		}
+	}
 
 	&.tag--no-link { cursor: initial;
 		opacity: 1; }
@@ -110,11 +122,6 @@ $tag-default-color: $color-gray-2;
 		border-radius: 0 3px 3px 0;
 		color: $color-text;
 		margin-left: 0;
-
-		&:not(.tag--no-link):hover,
-		&:not(.tag--no-link):focus {
-			color: $color-text;
-		}
 	}
 }
 


### PR DESCRIPTION
Added `.is-selectable` class to apply if a tag needs to be clickable

Completes #119 