### PR TITLE
Add icon sizing utility classes

### DIFF
--- a/src/pages/components/icons/code.js
+++ b/src/pages/components/icons/code.js
@@ -131,14 +131,88 @@ class Icons extends React.Component {
               </div>
             </div>
 
+            <h2 className="mt-space-xl" id="styles">Icon Sizing
+              <Link to={location.pathname + "/#icon-sizing"} className="button button--transparent button--copy-link"></Link>
+            </h2>
+            <div className="example-container">
+              <div className="card">
+                <div className="card-header">
+                  <h3>Custom sizing</h3>
+                </div>
+                <div className="card-content">
+                  <p>To change the size of an icon, add the class <code className="example-text">.dashing-icon--[size]</code>.</p>
+                  <i className="dashing-icon dashing-icon--info-filled dashing-icon--xs" style={{ marginRight: "0.25rem" }} />
+                  <i className="dashing-icon dashing-icon--info-filled dashing-icon--s" style={{ marginRight: "0.25rem" }} />
+                  <i className="dashing-icon dashing-icon--info-filled dashing-icon--m" style={{ marginRight: "0.25rem" }} />
+                  <i className="dashing-icon dashing-icon--info-filled dashing-icon--l" style={{ marginRight: "0.25rem" }} />
+                  <i className="dashing-icon dashing-icon--info-filled dashing-icon--xl" />
+                  <div className="show-code mt-space-xs mb-space-m">
+                    <CodeToggle>
+{`<i class="dashing-icon dashing-icon--info-filled dashing-icon--xs"></i>
+<i class="dashing-icon dashing-icon--info-filled dashing-icon--s"></i>
+<i class="dashing-icon dashing-icon--info-filled dashing-icon--m"></i>
+<i class="dashing-icon dashing-icon--info-filled dashing-icon--l"></i>
+<i class="dashing-icon dashing-icon--info-filled dashing-icon--xl"></i>
+`}
+                    </CodeToggle>
+                  </div>
+                  <div className="flex-table is-condensed font-small">
+                    <ol className="table-row--header">
+                      <li>Class</li>
+                      <li>Size</li>
+                    </ol>
+                    <ol className="table-row">
+                      <li><code className="example-text">dashing-icon--xs</code></li>
+                      <li>0.8rem</li>
+                    </ol>
+                    <ol className="table-row">
+                      <li><code className="example-text">dashing-icon--s</code></li>
+                      <li>0.9rem</li>
+                    </ol>
+                    <ol className="table-row">
+                      <li><code className="example-text">dashing-icon--m</code></li>
+                      <li>1.25rem</li>
+                    </ol>
+                    <ol className="table-row">
+                      <li><code className="example-text">dashing-icon--l</code></li>
+                      <li>1.563rem</li>
+                    </ol>
+                    <ol className="table-row">
+                      <li><code className="example-text">dashing-icon--xl</code></li>
+                      <li>1.953rem</li>
+                    </ol>
+                  </div>
+                </div>
+              </div>
+              <div className="card">
+                <div className="card-header">
+                  <h3>Relative sizing</h3>
+                </div>
+                <div className="card-content">
+                  <p>Nesting an icon inside of an element will make it take on the size of the parent container.</p>
+                  <h2 className="text-color--green">
+                    <i className="dashing-icon dashing-icon--checkmark-filled dashing-icon--green" />
+                    {" "}Success
+                  </h2>
+                  <div className="show-code mt-space-xs">
+                    <CodeToggle>
+{`<h2 class="text-color--green">
+  <i class="dashing-icon dashing-icon--checkmark-filled dashing-icon--green"></i>
+  Success
+</h2>`}
+                    </CodeToggle>
+                  </div>
+                </div>
+              </div>
+            </div>
+
             <h2 className="mt-space-xl" id="styles">Icons with Text
               <Link to={location.pathname + "/#icons-with-text"} className="button button--transparent button--copy-link"></Link>
             </h2>
             <div className="example-container">
               <div className="card">
                 <div className="card-header has-icon">
-                  <i className="dashing-icon dashing-icon--info-filled" />
-                  <h3>Card Header with Icon</h3>
+                  <h3><i className="dashing-icon dashing-icon--info-filled" />Card Header with Icon</h3>
                 </div>
                 <div className="card-content">
                   <p className="no-margin">This is an example of placing an icon in a card header</p>

--- a/src/sass/modules/icons/icons.scss
+++ b/src/sass/modules/icons/icons.scss
@@ -1,3 +1,124 @@
+// Icon map
+$icon-map: (
+	'arrow-down': '\e800',
+	'calendar': '\e801',
+	'checkmark-filled': '\e802',
+	'checkmark-stroke': '\e803',
+	'close': '\e804',
+	'comment-add': '\e806',
+	'comment': '\e807',
+	'do-not-pull': '\e808',
+	'do-not-push': '\e809',
+	'fit-page': '\e80a',
+	'fit-width': '\e80b',
+	'flip': '\e80c',
+	'hidden': '\e80d',
+	'info': '\e80e',
+	'info-filled': '\e80f',
+	'info-stroke': '\e810',
+	'location': '\e811',
+	'locked': '\e812',
+	'minus': '\e814',
+	'zoom-out': '\e814',
+	'new-tab': '\e815',
+	'notification': '\e816',
+	'page': '\e817',
+	'pencil': '\e818',
+	'phone': '\e818',
+	'play': '\e81b',
+	'plus': '\e81c',
+	'add': '\e81c',
+	'pull': '\e81d',
+	'push': '\e81e',
+	'question-filled': '\e81f',
+	'quicknav': '\e820',
+	'grid': '\e820',
+	'reply': '\e821',
+	'rotate': '\e822',
+	'search': '\e823',
+	'settings': '\e824',
+	'show': '\e825',
+	'time': '\e826',
+	'trash': '\e827',
+	'unlocked': '\e828',
+	'view-double': '\e829',
+	'arrow-left': '\e82a',
+	'arrow-long-down': '\e82b',
+	'arrow-long-left': '\e82c',
+	'arrow-long-up': '\e82d',
+	'arrow-right': '\e82e',
+	'arrow-up': '\e82f',
+	'heart': '\e832',
+	'question-stroke': '\e833',
+	'view-single': '\e834',
+	'checkmark': '\e835',
+	'arrow-long-right': '\e836',
+	'alert-stroke': '\e837',
+	'alert-filled': '\e838',
+	'add-person': '\e839',
+	//Below Added on Jan 15, 2018
+	'inbox': '\e83d',
+	'face-amazing': '\e83e',
+	'face-awful': '\e83f',
+	'face-ok': '\e840',
+	'face-good': '\e841',
+	'face-bad': '\e842',
+	'mobile-phone': '\e844',
+	'notification-off': '\e845',
+	'star-stroke': '\e847',
+	'star-filled': '\e831',
+	'star': '\e831',
+	'menu': '\e849',
+	'categories': '\e84a',
+	'mail': '\e81a',
+	'chat-filled': '\e813',
+	'popular': '\e830',
+	'paper-check': '\e83a',
+	'paper-check-2': '\e805',
+	//Added Feb 16, 2018
+	'pause': '\e846'
+);
+
+@each $name, $glyph in $icon-map {
+	.dashing-icon--#{$name}::before {
+		content: $glyph;
+	}
+}
+
+// Icon color map
+$icon-color-map: (
+	'white': $color-white,
+	'black': $color-black,
+	'blue': $color-blue,
+	'gray': $color-gray-3,
+	'grey': $color-gray-3,
+	'green': $color-green,
+	'orange': $color-orange,
+	'red': $color-red,
+	'purple': $color-purple
+);
+
+@each $name, $color in $icon-color-map {
+	.dashing-icon--#{$name}::before {
+		color: $color !important;
+	}
+}
+
+// Icon color map (mirrors typography sizes)
+$icon-size-map: (
+	'xs': $font-size-xsmall,
+	's': $font-size-small,
+	'm': $font-size-medium,
+	'l': $font-size-large,
+	'xl': $font-size-xlarge
+);
+
+@each $name, $size in $icon-size-map {
+	.dashing-icon--#{$name}::before {
+		font-size: $size !important;
+	}
+}
+
 @font-face {
 	font-family: 'dashing-icons';
 	font-style: normal;
@@ -11,7 +132,7 @@
 		color: $color-icon-primary;
 		display: inline-block;
 		font-family: 'dashing-icons';
-		font-size: 16px;
+		font-size: 1em; // Used em so icon takes the size of the parent
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
 		font-style: normal;
@@ -43,100 +164,6 @@
 		float: left;
 		margin: 0;
 	}
-
-	&.dashing-icon--white::before { color: $color-white; }
-	&.dashing-icon--black::before { color: $color-black; }
-	&.dashing-icon--blue::before { color: $color-blue; }
-
-	&.dashing-icon--gray::before,
-	&.dashing-icon--grey::before { color: $color-gray-3; }
-	&.dashing-icon--green::before { color: $color-green; }
-	&.dashing-icon--orange::before { color: $color-orange; }
-	&.dashing-icon--red::before { color: $color-red; }
-	&.dashing-icon--purple::before { color: $color-purple; }
-
-	//icon font codes
-
-	&.dashing-icon--arrow-down::before { content: '\e800'; } /* '' */
-	&.dashing-icon--calendar::before { content: '\e801'; } /* '' */
-	&.dashing-icon--checkmark-filled::before { content: '\e802'; } /* '' */
-	&.dashing-icon--checkmark-stroke::before { content: '\e803'; } /* '' */
-	&.dashing-icon--close::before { content: '\e804'; } /* '' */
-	&.dashing-icon--comment-add::before { content: '\e806'; } /* '' */
-	&.dashing-icon--comment::before { content: '\e807'; } /* '' */
-	&.dashing-icon--do-not-pull::before { content: '\e808'; } /* '' */
-	&.dashing-icon--do-not-push::before { content: '\e809'; } /* '' */
-	&.dashing-icon--fit-page::before { content: '\e80a'; } /* '' */
-	&.dashing-icon--fit-width::before { content: '\e80b'; } /* '' */
-	&.dashing-icon--flip::before { content: '\e80c'; } /* '' */
-	&.dashing-icon--hidden::before { content: '\e80d'; } /* '' */
-	&.dashing-icon--info::before { content: '\e80e'; } /* '' */
-	&.dashing-icon--info-filled::before { content: '\e80f'; } /* '' */
-	&.dashing-icon--info-stroke::before { content: '\e810'; } /* '' */
-	&.dashing-icon--location::before { content: '\e811'; } /* '' */
-	&.dashing-icon--locked::before { content: '\e812'; } /* '' */
-	&.dashing-icon--minus::before,
-	&.dashing-icon--zoom-out::before { content: '\e814'; } /* '' */
-	&.dashing-icon--new-tab::before { content: '\e815'; } /* '' */
-	&.dashing-icon--notification::before { content: '\e816'; } /* '' */
-	&.dashing-icon--page::before { content: '\e817'; } /* '' */
-	&.dashing-icon--pencil::before { content: '\e818'; } /* '' */
-	&.dashing-icon--phone::before { content: '\e819'; } /* '' */
-	&.dashing-icon--play::before { content: '\e81b'; } /* '' */
-	&.dashing-icon--plus::before,
-	&.dashing-icon--add::before,
-	&.dashing-icon--zoom-in::before { content: '\e81c'; } /* '' */
-	&.dashing-icon--pull::before { content: '\e81d'; } /* '' */
-	&.dashing-icon--push::before { content: '\e81e'; } /* '' */
-	&.dashing-icon--question-filled::before { content: '\e81f'; } /* '' */
-	&.dashing-icon--quicknav::before,
-	&.dashing-icon--grid::before { content: '\e820'; } /* '' */
-	&.dashing-icon--reply::before { content: '\e821'; } /* '' */
-	&.dashing-icon--rotate::before { content: '\e822'; } /* '' */
-	&.dashing-icon--search::before { content: '\e823'; } /* '' */
-	&.dashing-icon--settings::before { content: '\e824'; } /* '' */
-	&.dashing-icon--show::before { content: '\e825'; } /* '' */
-	&.dashing-icon--time::before { content: '\e826'; } /* '' */
-	&.dashing-icon--trash::before { content: '\e827'; } /* '' */
-	&.dashing-icon--unlocked::before { content: '\e828'; } /* '' */
-	&.dashing-icon--view-double::before { content: '\e829'; } /* '' */
-	&.dashing-icon--arrow-left::before { content: '\e82a'; } /* '' */
-	&.dashing-icon--arrow-long-down::before { content: '\e82b'; } /* '' */
-	&.dashing-icon--arrow-long-left::before { content: '\e82c'; } /* '' */
-	&.dashing-icon--arrow-long-up::before { content: '\e82d'; } /* '' */
-	&.dashing-icon--arrow-right::before { content: '\e82e'; } /* '' */
-	&.dashing-icon--arrow-up::before { content: '\e82f'; } /* '' */
-	&.dashing-icon--heart::before { content: '\e832'; } /* '' */
-	&.dashing-icon--question-stroke::before { content: '\e833'; } /* '' */
-	&.dashing-icon--view-single::before { content: '\e834'; } /* '' */
-	&.dashing-icon--checkmark::before { content: '\e835'; } /* '' */
-	&.dashing-icon--arrow-long-right::before { content: '\e836'; } /* '' */
-	&.dashing-icon--alert-stroke::before { content: '\e837'; } /* '' */
-	&.dashing-icon--alert-filled::before { content: '\e838'; } /* '' */
-	&.dashing-icon--add-person::before { content: '\e839'; } /* '' */
-
-	//Below Added on Jan 15, 2018
-	&.dashing-icon--inbox::before { content: '\e83d'; } /* '' */
-	&.dashing-icon--face-amazing::before { content: '\e83e'; } /* '' */
-	&.dashing-icon--face-awful::before { content: '\e83f'; } /* '' */
-	&.dashing-icon--face-ok::before { content: '\e840'; } /* '' */
-	&.dashing-icon--face-good::before { content: '\e841'; } /* '' */
-	&.dashing-icon--face-bad::before { content: '\e842'; } /* '' */
-	&.dashing-icon--mobile-phone::before { content: '\e844'; } /* '' */
-	&.dashing-icon--notification-off::before { content: '\e845'; } /* '' */
-	&.dashing-icon--star-stroke::before { content: '\e847'; } /* '' */
-	&.dashing-icon--star-filled::before,
-	&.dashing-icon--star::before { content: '\e831'; } /* '' */
-	&.dashing-icon--menu::before { content: '\e849'; } /* '' */
-	&.dashing-icon--categories::before { content: '\e84a'; } /* '' */
-	&.dashing-icon--mail::before { content: '\e81a'; } /* '' */
-	&.dashing-icon--chat-filled::before { content: '\e813'; } /* '' */
-	&.dashing-icon--popular::before { content: '\e830'; } /* '' */
-	&.dashing-icon--paper-check::before { content: '\e83a'; } /* '' */
-	&.dashing-icon--paper-check-2::before { content: '\e805'; } /* '' */
-
-	//Added Feb 16, 2018
-	&.dashing-icon--pause::before { content: '\e846'; } /* '' */
 }
 
 .flex.has-icon {

--- a/src/sass/modules/tooltip/_tooltip.scss
+++ b/src/sass/modules/tooltip/_tooltip.scss
@@ -11,6 +11,7 @@ i.paragon-clippy {
 	@extend .dashing-icon--question-filled;
 	cursor: help;
 	display: inline-block;
+	font-size: $font-size-normal;
 
 	@media #{$phone} {
 		border-radius: 50px;
@@ -20,13 +21,23 @@ i.paragon-clippy {
 	}
 }
 
-span .paragon-tooltip,
-p .paragon-tooltip,
-label .paragon-clippy {
-	margin-left: 0.2rem;
+span,
+p,
+label {
+	.paragon-clippy,
+	.paragon-tooltip {
+		margin-left: $space-xxs;
+	}
 }
 
-span.paragon-tooltip { display: inline-block; }
+// Center icon when used with a smaller label
+label {
+	.paragon-clippy,
+	.paragon-tooltip {
+		position: relative;
+		top: 0.1rem;
+	}
+}
 
 /* Custom Tippy.js Themes
   =========================================================================== */


### PR DESCRIPTION
Addresses #89 
- Add icon content and color values to scss maps (clean up the code a bit)
- Add examples for icon class utilities
- Change icon sizing to be relative to parent container

<img width="794" alt="Screen Shot 2020-12-15 at 11 33 46 AM" src="https://user-images.githubusercontent.com/26393016/102250674-722f8e80-3ec9-11eb-9d24-8035ac8d4df4.png">
<img width="800" alt="Screen Shot 2020-12-15 at 11 33 54 AM" src="https://user-images.githubusercontent.com/26393016/102250675-72c82500-3ec9-11eb-894e-cda7d9246b36.png">
