### PR TITLE
Change modal close button to 1rem size

### DIFF
--- a/src/sass/modules/modal/modal.scss
+++ b/src/sass/modules/modal/modal.scss
@@ -67,7 +67,7 @@
 		@include user-select(none);
 		cursor: pointer;
 		float: right;
-		font-size: 1.5rem;
+		font-size: 1rem;
 		margin-left: -2rem;
 		position: relative;
 		right: 0.7rem;


### PR DESCRIPTION
When updating the icons to match its parent, the modal close button got a little huge. Made it go back to 1rem.

Was: 
![image](https://user-images.githubusercontent.com/26393016/104057950-9294f500-51b8-11eb-91d0-772de5f2b816.png)

Now:
![image](https://user-images.githubusercontent.com/26393016/104057983-9fb1e400-51b8-11eb-834c-db9ac07ff477.png)
